### PR TITLE
Fix RAML content-type declaration

### DIFF
--- a/ramls/saml-login.raml
+++ b/ramls/saml-login.raml
@@ -46,7 +46,7 @@ schemas:
     post:
       description: Send callback to OKAPI after SSO authentication
       body:
-        application/x-www-form-urlencoded
+        application/x-www-form-urlencoded:
       responses:
         302:
           description: "Generate JWT token and set cookie"


### PR DESCRIPTION
Add missing colon.

raml-cop said: ERROR Property 'body' can not have scalar value