### PR TITLE
Revert "Fix RAML content-type declaration"

### DIFF
--- a/ramls/saml-login.raml
+++ b/ramls/saml-login.raml
@@ -46,7 +46,7 @@ schemas:
     post:
       description: Send callback to OKAPI after SSO authentication
       body:
-        application/x-www-form-urlencoded:
+        application/x-www-form-urlencoded
       responses:
         302:
           description: "Generate JWT token and set cookie"


### PR DESCRIPTION
This is broke the source generation with NPE

```
java.lang.NullPointerException
    at org.raml.jaxrs.codegen.core.AbstractGenerator.hasAMultiTypeFormParameter(AbstractGenerator.java:452)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.addFormParameters(AbstractGenerator.java:470)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.addBodyParameters(AbstractGenerator.java:535)
    at org.raml.jaxrs.codegen.core.Generator.addResourceMethod(Generator.java:189)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.addResourceMethods(AbstractGenerator.java:724)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.addResourceMethods(AbstractGenerator.java:292)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.addResourceMethods(AbstractGenerator.java:303)
    at org.raml.jaxrs.codegen.core.Generator.createResourceInterface(Generator.java:128)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.run(AbstractGenerator.java:224)
    at org.raml.jaxrs.codegen.core.AbstractGenerator.run(AbstractGenerator.java:780)
    at org.raml.jaxrs.codegen.core.GeneratorProxy.run(GeneratorProxy.java:40)
    at org.folio.rest.tools.GenerateRunner.main(GenerateRunner.java:110)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:282)
    at java.lang.Thread.run(Thread.java:745)
```