### PR TITLE
Avoid same name property files overwritten (MODLOGSAML-18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,9 @@
                 </filter>
               </filters>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/services/org.opensaml.core.config.Initializer</resource>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Main-Class>org.folio.rest.RestLauncher</Main-Class>


### PR DESCRIPTION
Hi Robert, I think I found out why the strange java.lang.NullPointerException at org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver.initMetadataResolver(DOMMetadataResolver.java:68) . Thanks.