### PR TITLE
Add "requires" section to module descriptor for required interfaces.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -48,5 +48,19 @@
         }
       ]
     }
+  ],
+  "requires": [
+    {
+      "id": "authtoken",
+      "version": "1.0"
+    },
+    {
+      "id": "users",
+      "version": "14.0"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
+    }
   ]
 }


### PR DESCRIPTION
Resolves MODLOGSAML-16