### PR TITLE
MODLOGSAML-44: remove required permissions from /saml/regenerate

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -32,7 +32,6 @@
           ],
           "pathPattern": "/saml/regenerate",
           "permissionsRequired": [
-            "login-saml.regenerate"
           ],
           "modulePermissions": [
             "configuration.entries.collection.get",


### PR DESCRIPTION
Note, call to /saml/regenerate endpoint does update the mod-config record for saml "metadata.invalidated". I have some concern about removing permission for this endpoint (see comments in the JIRA ticket). For now, please do **NOT** merge this PR.