### PR TITLE
MODLOGSAML-60 - add missing requiredPermissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,13 +4,14 @@
   "provides": [
     {
       "id": "login-saml",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": [
             "POST"
           ],
           "pathPattern": "/saml/login",
+          "permissionsRequired": [],
           "modulePermissions": [
             "configuration.entries.collection.get"
           ]
@@ -20,6 +21,7 @@
             "POST"
           ],
           "pathPattern": "/saml/callback",
+          "permissionsRequired": [],
           "modulePermissions": [
             "auth.signtoken",
             "configuration.entries.collection.get",
@@ -45,16 +47,31 @@
             "GET"
           ],
           "pathPattern": "/saml/check",
+          "permissionsRequired": [],
           "modulePermissions": [
             "configuration.entries.collection.get"
           ]
         },
         {
           "methods": [
-            "GET",
+            "GET"
+          ],
+          "pathPattern": "/saml/configuration",
+          "permissionsRequired": [
+            "login-saml.configuration.get"
+          ],
+          "modulePermissions": [
+            "configuration.entries.collection.get"
+          ]
+        },
+        {
+          "methods": [
             "PUT"
           ],
           "pathPattern": "/saml/configuration",
+          "permissionsRequired": [
+            "login-saml.configuration.put"
+          ],
           "modulePermissions": [
             "configuration.entries.collection.get",
             "configuration.entries.item.post",
@@ -65,7 +82,8 @@
           "methods": [
             "GET"
           ],
-          "pathPattern": "/saml/validate"
+          "pathPattern": "/saml/validate",
+          "permissionsRequired": []
         }
       ]
     }
@@ -77,11 +95,25 @@
       "description": ""
     },
     {
+      "permissionName": "login-saml.configuration.get",
+      "displayName": "SAML configuration: view",
+      "description": "Grants the ability to view SAML configuration",
+      "visible": true
+    },
+    {
+      "permissionName": "login-saml.configuration.put",
+      "displayName": "SAML configuration: modify",
+      "description": "Grants the ability to modify SAML configuration",
+      "visible": true
+    },
+    {
       "permissionName": "login-saml.all",
       "displayName": "Login-SAML: administration",
       "description": "",
       "subPermissions": [
-        "login-saml.regenerate"
+        "login-saml.regenerate",
+        "login-saml.configuration.get",
+        "login-saml.configuration.put"
       ],
       "visible": true
     }

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,8 @@
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <vertx.version>3.9.1</vertx.version>
     <pac4j.version>2.0.0</pac4j.version>
     <vertx-pac4j.version>3.0.0</vertx-pac4j.version>
-    <jackson.version>2.10.1</jackson.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
 
@@ -52,7 +50,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
-      <version>${vertx.version}</version>
     </dependency>
 
     <dependency>
@@ -97,7 +94,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -107,28 +103,21 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-unit</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-dropwizard-metrics</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>${jackson.version}</version>
+        <version>2.10.1</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
 
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.9.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
-
-
   </dependencyManagement>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,11 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <folio.domain-models-runtime.version>29.3.1</folio.domain-models-runtime.version>
+    <folio.domain-models-runtime.version>30.0.1</folio.domain-models-runtime.version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <vertx.version>3.8.5</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
     <pac4j.version>2.0.0</pac4j.version>
     <vertx-pac4j.version>3.0.0</vertx-pac4j.version>
     <jackson.version>2.10.1</jackson.version>

--- a/ramls/schemas/SamlCheck.json
+++ b/ramls/schemas/SamlCheck.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "Indicates whether or note SAML is configured and active",
   "properties": {
     "active": {
+      "description": "Indicates whether or note SAML is configured and active",
       "required": true,
       "type": "boolean"
     }

--- a/ramls/schemas/SamlConfig.json
+++ b/ramls/schemas/SamlConfig.json
@@ -1,13 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "Holds SAML configuration properties",
   "properties": {
     "idpUrl": {
+      "description": "the URL of the identity provider",
       "type": "string",
       "format": "uri",
       "required": true
     },
     "samlBinding": {
+      "description": "the SAML binding to use",
       "type": "string",
       "enum": [
         "POST",
@@ -16,10 +19,12 @@
       "required": false
     },
     "samlAttribute": {
+      "description": "the SAML attribute to use for matching against a FOLIO user",
       "type": "string",
       "required": false
     },
     "userProperty": {
+      "description": "the property from the user record to use for matching against the SAML attribute",
       "type": "string",
       "required": false
     },
@@ -29,6 +34,7 @@
       "required": false
     },
     "okapiUrl": {
+      "description": "Where to find OKAPI",
       "type": "string",
       "format": "uri",
       "required": true

--- a/ramls/schemas/SamlConfigRequest.json
+++ b/ramls/schemas/SamlConfigRequest.json
@@ -1,13 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "Holds SAML configuration properties",
   "properties": {
     "idpUrl": {
+      "description": "the URL of the identity provider",
       "type": "string",
       "format": "uri",
       "required": true
     },
     "samlBinding": {
+      "description": "the SAML binding to use",
       "type": "string",
       "enum": [
         "POST",
@@ -16,14 +19,17 @@
       "required": true
     },
     "samlAttribute": {
+      "description": "the SAML attribute to use for matching against a FOLIO user",
       "type": "string",
       "required": true
     },
     "userProperty": {
+      "description": "the property from the user record to use for matching against the SAML attribute",
       "type": "string",
       "required": true
     },
     "okapiUrl": {
+      "description": "Where to find OKAPI",
       "type": "string",
       "format": "uri",
       "required": true

--- a/ramls/schemas/SamlLogin.json
+++ b/ramls/schemas/SamlLogin.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "Payload response from the POST /saml/login endpoint",
   "properties": {
     "bindingMethod": {
+      "description": "the HTTP method binding to use",
       "required": true,
       "type": "string",
       "enum": [
@@ -11,14 +13,17 @@
       ]
     },
     "location": {
+      "description": "the URL to redirect to when using the GET/redirect binding",
       "required": true,
       "type": "string"
     },
     "samlRequest": {
+      "description": "the generated SAML request to be submitted when using the POST binding",
       "required": false,
       "type": "string"
     },
     "relayState": {
+      "description": "data that the IdP will echo back unchanged along with the SAML response",
       "required": false,
       "type": "string"
     }

--- a/ramls/schemas/SamlLoginRequest.json
+++ b/ramls/schemas/SamlLoginRequest.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "the payload sent to the POST /saml/login endpoint",
   "properties": {
     "stripesUrl": {
+      "description": "the URL that the user will be redirected to upon successful login",
       "required": true,
       "type": "string"
     }

--- a/ramls/schemas/SamlRegenerateResponse.json
+++ b/ramls/schemas/SamlRegenerateResponse.json
@@ -4,6 +4,7 @@
   "description": "Wraps sp metadata XML content (base64 encoded) in JSON.",
   "properties": {
     "fileContent": {
+      "description": "sp metadata",
       "required": true,
       "type": "string"
     }

--- a/ramls/schemas/SamlValidateResponse.json
+++ b/ramls/schemas/SamlValidateResponse.json
@@ -1,12 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-03/schema#",
   "type": "object",
+  "description": "Indicates whether or not the SAML configuration is valid",
   "properties": {
     "valid": {
+      "description": "Indicates whether or not the SAML configuration is valid",
       "required": true,
       "type": "boolean"
     },
     "error": {
+      "description": "Describes errors with the SAML configuration",
       "required": false,
       "type": "string"
     }

--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -115,7 +115,7 @@ public class ConfigurationsClient {
 
         });
       } else {
-        log.warn("Cannot save configuration entries: {}", compositeEvent.cause());
+        log.warn("Cannot save configuration entries: {}", compositeEvent.cause().getMessage());
         result.fail(compositeEvent.cause());
       }
     });

--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -37,16 +37,24 @@ public class ConfigurationsClient {
   public static final String MODULE_NAME = "LOGIN-SAML";
   public static final String CONFIG_NAME = "saml";
 
+  public static final String MISSING_OKAPI_URL = "Missing Okapi URL";
+  public static final String MISSING_TENANT = "Missing Tenant";
+  public static final String MISSING_TOKEN = "Missing Token";
+
+  private ConfigurationsClient() {
+
+  }
+
   public static Future<SamlConfiguration> getConfiguration(OkapiHeaders okapiHeaders) {
 
     if (Strings.isNullOrEmpty(okapiHeaders.getUrl())) {
-      return Future.failedFuture("Missing Okapi URL");
+      return Future.failedFuture(MISSING_OKAPI_URL);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getTenant())) {
-      return Future.failedFuture("Missing Tenant");
+      return Future.failedFuture(MISSING_TENANT);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getToken())) {
-      return Future.failedFuture("Missing Token");
+      return Future.failedFuture(MISSING_TOKEN);
     }
 
     Promise<SamlConfiguration> future = Promise.promise();
@@ -66,18 +74,18 @@ public class ConfigurationsClient {
           if (Response.isSuccess(response.getCode())) {
 
             JsonObject responseBody = response.getBody();
-            JsonArray configs = responseBody.getJsonArray("configs"); //{"configs": [],"total_records": 0}
+            JsonArray configs = responseBody.getJsonArray("configs");
 
             ConfigurationObjectMapper.map(configs, SamlConfiguration.class, future.future());
 
           } else {
-            log.warn("Cannot get configuration data: " + response.getError().toString());
+            log.warn("Cannot get configuration data: {}", response.getError());
             future.fail(response.getException());
           }
         });
 
     } catch (Exception e) {
-      log.warn("Cannot get configuration data: " + e.getMessage());
+      log.warn("Cannot get configuration data: {}", e.getMessage());
       future.fail(e);
     }
 
@@ -107,7 +115,7 @@ public class ConfigurationsClient {
 
         });
       } else {
-        log.warn("Cannot save configuration entries: " + compositeEvent.cause());
+        log.warn("Cannot save configuration entries: {}", compositeEvent.cause());
         result.fail(compositeEvent.cause());
       }
     });
@@ -121,13 +129,13 @@ public class ConfigurationsClient {
     Assert.hasText(code, "config entry CODE is mandatory");
 
     if (Strings.isNullOrEmpty(okapiHeaders.getUrl())) {
-      return Future.failedFuture("Missing Okapi URL");
+      return Future.failedFuture(MISSING_OKAPI_URL);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getTenant())) {
-      return Future.failedFuture("Missing Tenant");
+      return Future.failedFuture(MISSING_TENANT);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getToken())) {
-      return Future.failedFuture("Missing Token");
+      return Future.failedFuture(MISSING_TOKEN);
     }
 
 
@@ -198,13 +206,13 @@ public class ConfigurationsClient {
     Promise<String> result = Promise.promise();
 
     if (Strings.isNullOrEmpty(okapiHeaders.getUrl())) {
-      return Future.failedFuture("Missing Okapi URL");
+      return Future.failedFuture(MISSING_OKAPI_URL);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getTenant())) {
-      return Future.failedFuture("Missing Tenant");
+      return Future.failedFuture(MISSING_TENANT);
     }
     if (Strings.isNullOrEmpty(okapiHeaders.getToken())) {
-      return Future.failedFuture("Missing Token");
+      return Future.failedFuture(MISSING_TOKEN);
     }
 
     String query = "(module==" + MODULE_NAME + " AND configName==" + CONFIG_NAME + " AND code== " + code + ")";
@@ -219,7 +227,7 @@ public class ConfigurationsClient {
         .whenComplete((checkEntryResponse, throwable) -> {
           if (checkEntryResponse.getCode() != 200) {
             result.fail("Failed to check configuration entry: " + code
-              + " HTTP result was " + checkEntryResponse.getCode() + " " + String.valueOf(checkEntryResponse.getBody()));
+              + " HTTP result was " + checkEntryResponse.getCode() + " " + checkEntryResponse.getBody().encode());
           } else {
             JsonObject entries = checkEntryResponse.getBody();
             JsonArray configs = entries.getJsonArray("configs");

--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -95,9 +95,9 @@ public class ConfigurationsClient {
       .map(entry -> ConfigurationsClient.storeEntry(headers, entry.getKey(), entry.getValue()))
       .collect(Collectors.toList());
 
-    CompositeFuture.all(futures).setHandler(compositeEvent -> {
+    CompositeFuture.all(futures).onComplete(compositeEvent -> {
       if (compositeEvent.succeeded()) {
-        ConfigurationsClient.getConfiguration(headers).setHandler(newConfigHandler -> {
+        ConfigurationsClient.getConfiguration(headers).onComplete(newConfigHandler -> {
 
           if (newConfigHandler.succeeded()) {
             result.complete(newConfigHandler.result());
@@ -141,7 +141,7 @@ public class ConfigurationsClient {
       .put("value", value);
 
     // decide to POST or PUT
-    checkEntry(okapiHeaders, code).setHandler(checkHandler -> {
+    checkEntry(okapiHeaders, code).onComplete(checkHandler -> {
       if (checkHandler.failed()) {
         result.fail(checkHandler.cause());
       } else {

--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -101,7 +101,7 @@ public class ConfigurationsClient {
 
     Promise<SamlConfiguration> result = Promise.promise();
 
-    List<Future> futures = entries.entrySet().stream()
+    List<Future> futures = entries.entrySet().stream() //NOSONAR
       .map(entry -> ConfigurationsClient.storeEntry(headers, entry.getKey(), entry.getValue()))
       .collect(Collectors.toList());
 

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -222,7 +222,7 @@ public class SamlClientLoader {
 
   private static SAML2Client assembleSaml2Client(String okapiUrl, String tenantId, SAML2ClientConfiguration cfg, String samlBinding) {
 
-    boolean mock = System.getProperty(HttpClientMock2.MOCK_MODE) == "true";
+    boolean mock = Boolean.parseBoolean(System.getProperty(HttpClientMock2.MOCK_MODE));
 
     if (StringUtils.hasText(samlBinding) && samlBinding.equals("REDIRECT")) {
       cfg.setDestinationBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -83,7 +83,7 @@ public class SamlClientLoader {
                   if (samlClientInitHandler.failed()) {
                     clientInstantiationFuture.fail(samlClientInitHandler.cause());
                   } else {
-                    storeKeystore(okapiHeaders, vertx, keystoreFileName, actualKeystorePassword, actualPrivateKeyPassword).setHandler(keyfileStorageHandler -> {
+                    storeKeystore(okapiHeaders, vertx, keystoreFileName, actualKeystorePassword, actualPrivateKeyPassword).onComplete(keyfileStorageHandler -> {
                       if (keyfileStorageHandler.succeeded()) {
                         // storeKeystore is deleting JKS file, recreate client from byteArray
                         Buffer keystoreBytes = keyfileStorageHandler.result();
@@ -131,7 +131,7 @@ public class SamlClientLoader {
         }
 
 
-        clientInstantiationFuture.future().setHandler(result.future()::handle);
+        clientInstantiationFuture.future().onComplete(result.future()::handle);
         return result.future();
       });
 
@@ -168,7 +168,7 @@ public class SamlClientLoader {
             ConfigurationsClient.storeEntry(okapiHeaders, SamlConfiguration.KEYSTORE_PASSWORD_CODE, keystorePassword),
             ConfigurationsClient.storeEntry(okapiHeaders, SamlConfiguration.KEYSTORE_PRIVATEKEY_PASSWORD_CODE, privateKeyPassword),
             ConfigurationsClient.storeEntry(okapiHeaders, SamlConfiguration.METADATA_INVALIDATED_CODE, "true") // if keystore modified, current metasata is invalid.
-          ).setHandler(allConfigurationsStoredHandler -> {
+          ).onComplete(allConfigurationsStoredHandler -> {
 
             if (allConfigurationsStoredHandler.failed()) {
               vertx.fileSystem().delete(keystoreFileName, deleteResult ->

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -36,6 +36,10 @@ public class SamlClientLoader {
 
   public static final String CALLBACK_ENDPOINT = "/saml/callback";
 
+  private SamlClientLoader() {
+
+  }
+
   public static Future<SamlClientComposite> loadFromConfiguration(RoutingContext routingContext, boolean generateMissingKeyStore) {
 
     Promise<SamlClientComposite> result = Promise.promise();

--- a/src/main/java/org/folio/rest/impl/ApiInitializer.java
+++ b/src/main/java/org/folio/rest/impl/ApiInitializer.java
@@ -5,6 +5,7 @@ import io.vertx.core.*;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.util.WebClientFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -19,6 +20,7 @@ public class ApiInitializer implements InitAPI {
 
   @Override
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
+    WebClientFactory.init(vertx);
 
     String tacEnv = System.getenv("TRUST_ALL_CERTIFICATES");
 

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -138,7 +138,7 @@ public class SamlAPI implements Saml {
             SAML2Credentials credentials = client.getCredentials(webContext);
 
             // Get user id
-            List samlAttributeList = (List) credentials.getUserProfile().getAttribute(samlAttributeName);
+            List<?> samlAttributeList = (List<?>) credentials.getUserProfile().getAttribute(samlAttributeName);
             if (samlAttributeList == null || samlAttributeList.isEmpty()) {
               asyncResultHandler.handle(Future.succeededFuture(PostSamlCallbackResponse.respond400WithTextPlain("SAML attribute doesn't exist: " + samlAttributeName)));
               return;
@@ -412,13 +412,13 @@ public class SamlAPI implements Saml {
 
     Promise<Void> result = Promise.promise();
 
-    List<Future> futures = Arrays.asList(UrlUtil.checkIdpUrl(updatedConfig.getIdpUrl().toString(), vertx));
+    List<Future> futures = Arrays.asList(UrlUtil.checkIdpUrl(updatedConfig.getIdpUrl().toString(), vertx)); //NOSONAR
 
     CompositeFuture.all(futures)
       .onComplete(hnd -> {
         if (hnd.succeeded()) {
           // all success
-          Optional<Future> failedCheck = futures.stream()
+          Optional<Future> failedCheck = futures.stream() //NOSONAR
             .filter(future -> !((UrlCheckResult) future.result()).getStatus().equals(UrlCheckResult.Status.SUCCESS))
             .findFirst();
 

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -1,7 +1,6 @@
 package org.folio.util;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.folio.util.model.UrlCheckResult;
 

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -1,20 +1,23 @@
 package org.folio.util;
 
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import org.folio.util.model.UrlCheckResult;
-
-import javax.ws.rs.core.MediaType;
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import org.folio.util.model.UrlCheckResult;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
 
 /**
  * @author rsass
  */
 public class UrlUtil {
 
+  private UrlUtil() {
+
+  }
 
   public static URI parseBaseUrl(URI originalUrl) {
     try {
@@ -25,33 +28,27 @@ public class UrlUtil {
   }
 
   public static Future<UrlCheckResult> checkIdpUrl(String url, Vertx vertx) {
-    HttpClient client = createClient(vertx);
-    return checkIdpUrl(url, client);
-  }
+    Promise<UrlCheckResult> promise = Promise.promise();
 
-  public static Future<UrlCheckResult> checkIdpUrl(String url, HttpClient client) {
+    WebClient client = WebClientFactory.getWebClient(vertx);
 
-    Future<UrlCheckResult> future = Future.future();
-
-
-    try {
-      client.getAbs(url, responseHandler -> {
-        String contentType = responseHandler.getHeader("Content-Type");
-        if (contentType.contains("xml")) {
-          future.complete(UrlCheckResult.emptySuccessResult());
-        } else {
-          future.complete(UrlCheckResult.failResult("Response content-type is not XML"));
+    client.getAbs(url).send(ar -> {
+      try {
+        if (ar.failed()) {
+          promise.complete(UrlCheckResult.failResult(ar.cause().getMessage()));
+          return;
         }
-      }).exceptionHandler(exc -> future.complete(UrlCheckResult.failResult(exc.getMessage()))).end();
-    } catch (Exception e) {
-      future.complete(UrlCheckResult.failResult(e.getMessage()));
-    }
+        String contentType = ar.result().getHeader("Content-Type");
+        if (contentType.contains("xml")) {
+          promise.complete(UrlCheckResult.emptySuccessResult());
+          return;
+        }
+        promise.complete(UrlCheckResult.failResult("Response content-type is not XML"));
+      } catch (Exception e) {
+        promise.complete(UrlCheckResult.failResult("Unexpected error: " + e.getMessage()));
+      }
+    });
 
-    return future;
-  }
-
-  private static HttpClient createClient(Vertx vertx) {
-    HttpClientOptions options = new HttpClientOptions().setKeepAlive(false).setConnectTimeout(5000);
-    return vertx.createHttpClient(options);
+    return promise.future();
   }
 }

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -20,11 +20,7 @@ public class UrlUtil {
   }
 
   public static URI parseBaseUrl(URI originalUrl) {
-    try {
-      return new URI(originalUrl.getScheme() + "://" + originalUrl.getAuthority());
-    } catch (URISyntaxException e) {
-      throw new IllegalStateException("Malformed URI...", e);
-    }
+      return URI.create(originalUrl.getScheme() + "://" + originalUrl.getAuthority());
   }
 
   public static Future<UrlCheckResult> checkIdpUrl(String url, Vertx vertx) {

--- a/src/main/java/org/folio/util/WebClientFactory.java
+++ b/src/main/java/org/folio/util/WebClientFactory.java
@@ -1,0 +1,39 @@
+package org.folio.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+
+public class WebClientFactory {
+
+  public static final int DEFAULT_TIMEOUT = 5000;
+  public static final boolean DEFAULT_KEEPALIVE = false;
+  
+  private static Map<Vertx, WebClient> clients = new HashMap<>();
+
+  public static WebClient getWebClient(Vertx vertx) {
+    return clients.get(vertx);
+  }
+
+  private WebClientFactory() {
+  }
+
+  /**
+   * Initializes a WebClient for the provided Vertx.
+   * Calling this method more than once with the same Vertx has no effect.
+   *
+   * @param vertx
+   */
+  public static synchronized void init(Vertx vertx) {
+    if (vertx != null && !clients.containsKey(vertx)) {
+      WebClientOptions options = new WebClientOptions();
+      options.setKeepAlive(DEFAULT_KEEPALIVE);
+      options.setConnectTimeout(DEFAULT_TIMEOUT);
+      options.setIdleTimeout(DEFAULT_TIMEOUT);
+      clients.put(vertx, WebClient.create(vertx, options));
+    }
+  }
+}

--- a/src/test/java/org/folio/config/ConfigurationClientTest.java
+++ b/src/test/java/org/folio/config/ConfigurationClientTest.java
@@ -1,0 +1,60 @@
+package org.folio.config;
+
+import static org.folio.config.ConfigurationsClient.MISSING_OKAPI_URL;
+import static org.folio.config.ConfigurationsClient.MISSING_TENANT;
+import static org.folio.config.ConfigurationsClient.MISSING_TOKEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.folio.config.ConfigurationsClient.MissingHeaderException;
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.util.model.OkapiHeaders;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class ConfigurationClientTest {
+
+  @Test
+  public void testVerifyOkapiHeaders() {
+    OkapiHeaders okapiHeaders = new OkapiHeaders();
+    okapiHeaders.setTenant("tenant");
+    okapiHeaders.setToken("token");
+    okapiHeaders.setUrl("url");
+    try {
+      ConfigurationsClient.verifyOkapiHeaders(okapiHeaders);
+    } catch (MissingHeaderException e) {
+      fail(e.getMessage());
+    }
+
+    okapiHeaders = new OkapiHeaders();
+    okapiHeaders.setTenant("tenant");
+    okapiHeaders.setUrl("url");
+    try {
+      ConfigurationsClient.verifyOkapiHeaders(okapiHeaders);
+    } catch (MissingHeaderException e) {
+      assertEquals(MISSING_TOKEN, e.getMessage());
+    }
+
+    okapiHeaders = new OkapiHeaders();
+    okapiHeaders.setToken("token");
+    okapiHeaders.setUrl("url");
+    try {
+      ConfigurationsClient.verifyOkapiHeaders(okapiHeaders);
+    } catch (MissingHeaderException e) {
+      assertEquals(MISSING_TENANT, e.getMessage());
+    }
+
+    okapiHeaders = new OkapiHeaders();
+    okapiHeaders.setTenant("tenant");
+    okapiHeaders.setToken("token");
+    try {
+      ConfigurationsClient.verifyOkapiHeaders(okapiHeaders);
+    } catch (MissingHeaderException e) {
+      assertEquals(MISSING_OKAPI_URL, e.getMessage());
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -212,7 +212,7 @@ public class SamlAPITest {
   @Test
   public void putConfigurationEndpoint(TestContext context) throws IOException {
     SamlConfigRequest samlConfigRequest = new SamlConfigRequest()
-      .withIdpUrl(URI.create("http://localhost:" + MOCK_PORT))
+      .withIdpUrl(URI.create("http://localhost:" + MOCK_PORT + "/xml"))
       .withSamlAttribute("UserID")
       .withSamlBinding(SamlConfigRequest.SamlBinding.POST)
       .withUserProperty("externalSystemId")

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -63,13 +63,7 @@ public class SamlAPITest {
       .setConfig(new JsonObject().put("http.port", MOCK_PORT))
       .setWorker(true);
 
-    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, mockRes -> {
-      if(mockRes.failed()) {
-        context.fail(mockRes.cause());
-      } else {
-        context.asyncAssertSuccess();
-      }
-    });
+    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, context.asyncAssertSuccess());
   }
 
   @Before
@@ -84,9 +78,7 @@ public class SamlAPITest {
     RestAssured.port = PORT;
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
-    vertx.deployVerticle(new RestVerticle(),
-        options,
-        context.asyncAssertSuccess());
+    vertx.deployVerticle(new RestVerticle(), options, context.asyncAssertSuccess());
   }
 
   @After

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -1,5 +1,32 @@
 package org.folio.rest.impl;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.SamlConfigRequest;
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.util.IdpMock;
+import org.folio.util.TestingClasspathResolver;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.ls.LSResourceResolver;
+
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
@@ -9,28 +36,6 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.rest.RestVerticle;
-import org.folio.rest.jaxrs.model.SamlConfigRequest;
-import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.util.TestingClasspathResolver;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.ls.LSResourceResolver;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URLEncoder;
-
-import static io.restassured.RestAssured.given;
-import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
-import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * @author rsass
@@ -46,32 +51,52 @@ public class SamlAPITest {
   private static final String STRIPES_URL = "http://localhost:3000";
 
   public static final int PORT = 8081;
+  public static final int MOCK_PORT = NetworkUtils.nextFreePort();
+
+  private static Vertx mockVertx = Vertx.vertx();
+
   private Vertx vertx;
 
+  @BeforeClass
+  public static void setupOnce(TestContext context) throws Exception {
+    DeploymentOptions mockOptions = new DeploymentOptions()
+      .setConfig(new JsonObject().put("http.port", MOCK_PORT))
+      .setWorker(true);
+
+    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, mockRes -> {
+      if(mockRes.failed()) {
+        context.fail(mockRes.cause());
+      } else {
+        context.asyncAssertSuccess();
+      }
+    });
+  }
 
   @Before
   public void setUp(TestContext context) throws Exception {
     vertx = Vertx.vertx();
-
 
     DeploymentOptions options = new DeploymentOptions()
       .setConfig(new JsonObject().put("http.port", PORT)
         .put(HttpClientMock2.MOCK_MODE, "true")
       );
 
-
-    vertx.deployVerticle(new RestVerticle(),
-      options,
-      context.asyncAssertSuccess());
-
     RestAssured.port = PORT;
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
+    vertx.deployVerticle(new RestVerticle(),
+        options,
+        context.asyncAssertSuccess());
   }
 
   @After
   public void tearDown(TestContext context) throws Exception {
     vertx.close(context.asyncAssertSuccess());
+  }
+
+  @AfterClass
+  public static void tearDownOnce(TestContext context) throws Exception {
+    mockVertx.close(context.asyncAssertSuccess());
   }
 
   @Test
@@ -98,7 +123,7 @@ public class SamlAPITest {
   }
 
   @Test
-  public void loginEndpointTests() {
+  public void loginEndpointTests() throws IOException {
 
     // empty body
     given()
@@ -124,7 +149,6 @@ public class SamlAPITest {
       .body("bindingMethod", equalTo("POST"))
       .body("relayState", equalTo(STRIPES_URL))
       .statusCode(200);
-
   }
 
   @Test
@@ -185,13 +209,10 @@ public class SamlAPITest {
       .body("metadataInvalidated", equalTo(Boolean.FALSE));
   }
 
-  @Ignore("2 external http servers should be mocked")
   @Test
-  public void putConfigurationEndpoint() {
-
-
+  public void putConfigurationEndpoint(TestContext context) throws IOException {
     SamlConfigRequest samlConfigRequest = new SamlConfigRequest()
-      .withIdpUrl(URI.create("http://localhost"))
+      .withIdpUrl(URI.create("http://localhost:" + MOCK_PORT))
       .withSamlAttribute("UserID")
       .withSamlBinding(SamlConfigRequest.SamlBinding.POST)
       .withUserProperty("externalSystemId")
@@ -210,7 +231,6 @@ public class SamlAPITest {
       .then()
       .statusCode(200)
       .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlConfig.json"));
-
   }
 
   @Test

--- a/src/test/java/org/folio/util/Base64UtilTest.java
+++ b/src/test/java/org/folio/util/Base64UtilTest.java
@@ -25,7 +25,7 @@ public class Base64UtilTest {
   public void encode(TestContext context) throws Exception {
 
     Base64Util.encode(rule.vertx().getOrCreateContext(), HELLO)
-      .setHandler(context.asyncAssertSuccess(result -> context.assertEquals(HELLO_AS_BASE64, result.toString(StandardCharsets.UTF_8))));
+      .onComplete(context.asyncAssertSuccess(result -> context.assertEquals(HELLO_AS_BASE64, result.toString(StandardCharsets.UTF_8))));
 
   }
 

--- a/src/test/java/org/folio/util/IdpMock.java
+++ b/src/test/java/org/folio/util/IdpMock.java
@@ -20,7 +20,9 @@ public class IdpMock extends AbstractVerticle {
     Router router = Router.router(vertx);
     HttpServer server = vertx.createHttpServer();
 
-    router.route().handler(this::handleIdp);
+    router.route("/xml").handler(this::handleXml);
+    router.route("/json").handler(this::handleJson);
+    router.route("/").handler(this::handleNoContentType);
     System.out.println("Running IdpMock on port " + port);
     server.requestHandler(router::handle).listen(port, result -> {
       if (result.failed()) {
@@ -31,12 +33,24 @@ public class IdpMock extends AbstractVerticle {
     });
   }
 
-  private void handleIdp(RoutingContext context) {
+  private void handleNoContentType(RoutingContext context) {
+    handle(context, null);
+  }
+
+  private void handleXml(RoutingContext context) {
+    handle(context, "application/xml");
+  }
+
+  private void handleJson(RoutingContext context) {
+    handle(context, "application/json");
+  }
+
+  private void handle(RoutingContext context, String contentType) {
     try {
       String idpMetadata = readMockData();
       context.response()
         .setStatusCode(200)
-        .putHeader("Content-Type", "application/xml")
+        .putHeader("Content-Type", contentType)
         .end(idpMetadata);
     } catch (Exception e) {
       context.response()

--- a/src/test/java/org/folio/util/IdpMock.java
+++ b/src/test/java/org/folio/util/IdpMock.java
@@ -1,0 +1,52 @@
+package org.folio.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServer;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public class IdpMock extends AbstractVerticle {
+
+  public void start(Promise<Void> promise) {
+    final int port = context.config().getInteger("http.port");
+
+    Router router = Router.router(vertx);
+    HttpServer server = vertx.createHttpServer();
+
+    router.route().handler(this::handleIdp);
+    System.out.println("Running IdpMock on port " + port);
+    server.requestHandler(router::handle).listen(port, result -> {
+      if (result.failed()) {
+        promise.fail(result.cause());
+      } else {
+        promise.complete();
+      }
+    });
+  }
+
+  private void handleIdp(RoutingContext context) {
+    try {
+      String idpMetadata = readMockData();
+      context.response()
+        .setStatusCode(200)
+        .putHeader("Content-Type", "application/xml")
+        .end(idpMetadata);
+    } catch (Exception e) {
+      context.response()
+        .setStatusCode(500)
+        .end(e.getMessage());
+    }
+  }
+
+  private String readMockData() throws IOException {
+    Path path = Paths.get("src/test/resources/meta-idp.xml");
+    return new String(Files.readAllBytes(path));
+  }
+}

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -62,7 +62,7 @@ public class UrlUtilTest {
     Async async = context.async();
 
     UrlUtil.checkIdpUrl("http://localhost:" + server.actualPort(), rule.vertx())
-      .setHandler(handler -> {
+      .onComplete(handler -> {
         if (handler.failed()) {
           context.fail(handler.cause());
         } else {

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -50,6 +50,7 @@ public class UrlUtilTest {
         log.info("Running test http listener on port " + hnd.actualPort());
       }));
 
+    WebClientFactory.init(rule.vertx());
   }
 
   @After

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -2,10 +2,8 @@ package org.folio.util;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
 
 import org.folio.rest.tools.utils.NetworkUtils;
-import org.folio.util.model.UrlCheckResult;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -17,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
@@ -34,16 +31,11 @@ public class UrlUtilTest {
 
   @BeforeClass
   public static void setupOnce(TestContext context) throws Exception {
-    DeploymentOptions mockOptions = new DeploymentOptions().setConfig(new JsonObject().put("http.port", MOCK_PORT))
-      .setWorker(true);
+    DeploymentOptions mockOptions = new DeploymentOptions().setConfig(new JsonObject()
+        .put("http.port", MOCK_PORT))
+        .setWorker(true);
 
-    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, mockRes -> {
-      if (mockRes.failed()) {
-        context.fail(mockRes.cause());
-      } else {
-        context.asyncAssertSuccess();
-      }
-    });
+    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, context.asyncAssertSuccess());
   }
 
   @Before
@@ -59,65 +51,33 @@ public class UrlUtilTest {
 
   @Test
   public void checkIdpUrl(TestContext context) throws MalformedURLException {
-    Async async = context.async();
-
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/xml", vertx)
-      .onComplete(handler -> {
-        if (handler.failed()) {
-          context.fail(handler.cause());
-        } else {
-          UrlCheckResult result = handler.result();
-          context.assertEquals("", result.getMessage());
-          async.complete();
-        }
-      });
+      .onComplete(context.asyncAssertSuccess(result -> {
+        context.assertEquals("", result.getMessage());
+      }));
   }
 
   @Test
   public void checkIdpUrlNon200(TestContext context) {
-    Async async = context.async();
-
     UrlUtil.checkIdpUrl("http://localhost:0", vertx)
-      .onComplete(handler -> {
-        if (handler.failed()) {
-          context.fail(handler.cause());
-        } else {
-          UrlCheckResult result = handler.result();
+      .onComplete(context.asyncAssertSuccess(result -> {
           context.assertEquals("Connection refused: localhost/127.0.0.1:0", result.getMessage());
-          async.complete();
-        }
-      });
+      }));
   }
 
   @Test
   public void checkIdpUrlUnexpectedError(TestContext context) {
-    Async async = context.async();
-
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/", vertx)
-      .onComplete(handler -> {
-        if (handler.failed()) {
-          context.fail(handler.cause());
-        } else {
-          UrlCheckResult result = handler.result();
-          context.assertEquals("Unexpected error: null", result.getMessage());
-          async.complete();
-        }
-      });
+      .onComplete(context.asyncAssertSuccess(result -> {
+        context.assertEquals("Unexpected error: null", result.getMessage());
+      }));
   }
 
   @Test
   public void checkIdpUrlJson(TestContext context) {
-    Async async = context.async();
-
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/json", vertx)
-      .onComplete(handler -> {
-        if (handler.failed()) {
-          context.fail(handler.cause());
-        } else {
-          UrlCheckResult result = handler.result();
-          context.assertEquals("Response content-type is not XML", result.getMessage());
-          async.complete();
-        }
-      });
+      .onComplete(context.asyncAssertSuccess(result -> {
+        context.assertEquals("Response content-type is not XML", result.getMessage());
+      }));
   }
 }

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -1,77 +1,123 @@
 package org.folio.util;
 
-import io.vertx.core.http.HttpServer;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RepeatRule;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+
+import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.util.model.UrlCheckResult;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.ServerSocket;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class UrlUtilTest {
 
   private static final Logger log = LoggerFactory.getLogger(UrlUtilTest.class);
 
-  @Rule
-  public RunTestOnContext rule = new RunTestOnContext();
+  public static final int MOCK_PORT = NetworkUtils.nextFreePort();
 
-  @Rule
-  public RepeatRule repeatRule = new RepeatRule();
+  private static Vertx mockVertx = Vertx.vertx();
 
-  private HttpServer server;
+  private Vertx vertx;
 
+  @BeforeClass
+  public static void setupOnce(TestContext context) throws Exception {
+    DeploymentOptions mockOptions = new DeploymentOptions().setConfig(new JsonObject().put("http.port", MOCK_PORT))
+      .setWorker(true);
+
+    mockVertx.deployVerticle(IdpMock.class.getName(), mockOptions, mockRes -> {
+      if (mockRes.failed()) {
+        context.fail(mockRes.cause());
+      } else {
+        context.asyncAssertSuccess();
+      }
+    });
+  }
 
   @Before
   public void before(TestContext context) throws IOException {
-
-    // obtain a free port
-    ServerSocket ss = new ServerSocket(0);
-    int port = ss.getLocalPort();
-    ss.close();
-
-    server = rule.vertx().createHttpServer().requestHandler(req -> {
-      req.response()
-        .putHeader("Content-Type", "application/xml")
-        .end("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
-    }).
-      listen(port, context.asyncAssertSuccess(hnd -> {
-        log.info("Running test http listener on port " + hnd.actualPort());
-      }));
-
-    WebClientFactory.init(rule.vertx());
+    vertx = Vertx.vertx();
+    WebClientFactory.init(vertx);
   }
 
-  @After
-  public void after(TestContext context) {
-    server.close(context.asyncAssertSuccess());
+  @AfterClass
+  public static void afterOnce(TestContext context) {
+    mockVertx.close(context.asyncAssertSuccess());
   }
 
   @Test
   public void checkIdpUrl(TestContext context) throws MalformedURLException {
     Async async = context.async();
 
-    UrlUtil.checkIdpUrl("http://localhost:" + server.actualPort(), rule.vertx())
+    UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/xml", vertx)
       .onComplete(handler -> {
         if (handler.failed()) {
           context.fail(handler.cause());
         } else {
           UrlCheckResult result = handler.result();
-          log.info("Result is {} with message {}", result.getStatus(), result.getMessage());
+          context.assertEquals("", result.getMessage());
           async.complete();
         }
       });
+  }
 
+  @Test
+  public void checkIdpUrlNon200(TestContext context) {
+    Async async = context.async();
+
+    UrlUtil.checkIdpUrl("http://localhost:0", vertx)
+      .onComplete(handler -> {
+        if (handler.failed()) {
+          context.fail(handler.cause());
+        } else {
+          UrlCheckResult result = handler.result();
+          context.assertEquals("Connection refused: localhost/127.0.0.1:0", result.getMessage());
+          async.complete();
+        }
+      });
+  }
+
+  @Test
+  public void checkIdpUrlUnexpectedError(TestContext context) {
+    Async async = context.async();
+
+    UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/", vertx)
+      .onComplete(handler -> {
+        if (handler.failed()) {
+          context.fail(handler.cause());
+        } else {
+          UrlCheckResult result = handler.result();
+          context.assertEquals("Unexpected error: null", result.getMessage());
+          async.complete();
+        }
+      });
+  }
+
+  @Test
+  public void checkIdpUrlJson(TestContext context) {
+    Async async = context.async();
+
+    UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/json", vertx)
+      .onComplete(handler -> {
+        if (handler.failed()) {
+          context.fail(handler.cause());
+        } else {
+          UrlCheckResult result = handler.result();
+          context.assertEquals("Response content-type is not XML", result.getMessage());
+          async.complete();
+        }
+      });
   }
 }

--- a/src/test/resources/meta-idp.xml
+++ b/src/test/resources/meta-idp.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<EntityDescriptor entityID="https://idp.ssocircle.com" xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+    <IDPSSODescriptor WantAuthnRequestsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor use="signing">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>
+MIIEYzCCAkugAwIBAgIDIAZmMA0GCSqGSIb3DQEBCwUAMC4xCzAJBgNVBAYTAkRF
+MRIwEAYDVQQKDAlTU09DaXJjbGUxCzAJBgNVBAMMAkNBMB4XDTE2MDgwMzE1MDMy
+M1oXDTI2MDMwNDE1MDMyM1owPTELMAkGA1UEBhMCREUxEjAQBgNVBAoTCVNTT0Np
+cmNsZTEaMBgGA1UEAxMRaWRwLnNzb2NpcmNsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCAwWJyOYhYmWZF2TJvm1VyZccs3ZJ0TsNcoazr2pTW
+cY8WTRbIV9d06zYjngvWibyiylewGXcYONB106ZNUdNgrmFd5194Wsyx6bPvnjZE
+ERny9LOfuwQaqDYeKhI6c+veXApnOfsY26u9Lqb9sga9JnCkUGRaoVrAVM3yfghv
+/Cg/QEg+I6SVES75tKdcLDTt/FwmAYDEBV8l52bcMDNF+JWtAuetI9/dWCBe9VTC
+asAr2Fxw1ZYTAiqGI9sW4kWS2ApedbqsgH3qqMlPA7tg9iKy8Yw/deEn0qQIx8Gl
+VnQFpDgzG9k+jwBoebAYfGvMcO/BDXD2pbWTN+DvbURlAgMBAAGjezB5MAkGA1Ud
+EwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmlj
+YXRlMB0GA1UdDgQWBBQhAmCewE7aonAvyJfjImCRZDtccTAfBgNVHSMEGDAWgBTA
+1nEA+0za6ppLItkOX5yEp8cQaTANBgkqhkiG9w0BAQsFAAOCAgEAAhC5/WsF9ztJ
+Hgo+x9KV9bqVS0MmsgpG26yOAqFYwOSPmUuYmJmHgmKGjKrj1fdCINtzcBHFFBC1
+maGJ33lMk2bM2THx22/O93f4RFnFab7t23jRFcF0amQUOsDvltfJw7XCal8JdgPU
+g6TNC4Fy9XYv0OAHc3oDp3vl1Yj8/1qBg6Rc39kehmD5v8SKYmpE7yFKxDF1ol9D
+KDG/LvClSvnuVP0b4BWdBAA9aJSFtdNGgEvpEUqGkJ1osLVqCMvSYsUtHmapaX3h
+iM9RbX38jsSgsl44Rar5Ioc7KXOOZFGfEKyyUqucYpjWCOXJELAVAzp7XTvA2q55
+u31hO0w8Yx4uEQKlmxDuZmxpMz4EWARyjHSAuDKEW1RJvUr6+5uA9qeOKxLiKN1j
+o6eWAcl6Wr9MreXR9kFpS6kHllfdVSrJES4ST0uh1Jp4EYgmiyMmFCbUpKXifpsN
+WCLDenE3hllF0+q3wIdu+4P82RIM71n7qVgnDnK29wnLhHDat9rkC62CIbonpkVY
+mnReX0jze+7twRanJOMCJ+lFg16BDvBcG8u0n/wIDkHHitBI7bU1k6c6DydLQ+69
+h8SCo6sO9YuD+/3xAGKad4ImZ6vTwlB4zDCpu6YgQWocWRXE+VkOb+RBfvP755PU
+aLfL63AFVlpOnEpIio5++UjNJRuPuAA=
+                   </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+        </KeyDescriptor>
+        <KeyDescriptor use="encryption">
+            <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>
+MIIEYzCCAkugAwIBAgIDIAZmMA0GCSqGSIb3DQEBCwUAMC4xCzAJBgNVBAYTAkRF
+MRIwEAYDVQQKDAlTU09DaXJjbGUxCzAJBgNVBAMMAkNBMB4XDTE2MDgwMzE1MDMy
+M1oXDTI2MDMwNDE1MDMyM1owPTELMAkGA1UEBhMCREUxEjAQBgNVBAoTCVNTT0Np
+cmNsZTEaMBgGA1UEAxMRaWRwLnNzb2NpcmNsZS5jb20wggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCAwWJyOYhYmWZF2TJvm1VyZccs3ZJ0TsNcoazr2pTW
+cY8WTRbIV9d06zYjngvWibyiylewGXcYONB106ZNUdNgrmFd5194Wsyx6bPvnjZE
+ERny9LOfuwQaqDYeKhI6c+veXApnOfsY26u9Lqb9sga9JnCkUGRaoVrAVM3yfghv
+/Cg/QEg+I6SVES75tKdcLDTt/FwmAYDEBV8l52bcMDNF+JWtAuetI9/dWCBe9VTC
+asAr2Fxw1ZYTAiqGI9sW4kWS2ApedbqsgH3qqMlPA7tg9iKy8Yw/deEn0qQIx8Gl
+VnQFpDgzG9k+jwBoebAYfGvMcO/BDXD2pbWTN+DvbURlAgMBAAGjezB5MAkGA1Ud
+EwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVkIENlcnRpZmlj
+YXRlMB0GA1UdDgQWBBQhAmCewE7aonAvyJfjImCRZDtccTAfBgNVHSMEGDAWgBTA
+1nEA+0za6ppLItkOX5yEp8cQaTANBgkqhkiG9w0BAQsFAAOCAgEAAhC5/WsF9ztJ
+Hgo+x9KV9bqVS0MmsgpG26yOAqFYwOSPmUuYmJmHgmKGjKrj1fdCINtzcBHFFBC1
+maGJ33lMk2bM2THx22/O93f4RFnFab7t23jRFcF0amQUOsDvltfJw7XCal8JdgPU
+g6TNC4Fy9XYv0OAHc3oDp3vl1Yj8/1qBg6Rc39kehmD5v8SKYmpE7yFKxDF1ol9D
+KDG/LvClSvnuVP0b4BWdBAA9aJSFtdNGgEvpEUqGkJ1osLVqCMvSYsUtHmapaX3h
+iM9RbX38jsSgsl44Rar5Ioc7KXOOZFGfEKyyUqucYpjWCOXJELAVAzp7XTvA2q55
+u31hO0w8Yx4uEQKlmxDuZmxpMz4EWARyjHSAuDKEW1RJvUr6+5uA9qeOKxLiKN1j
+o6eWAcl6Wr9MreXR9kFpS6kHllfdVSrJES4ST0uh1Jp4EYgmiyMmFCbUpKXifpsN
+WCLDenE3hllF0+q3wIdu+4P82RIM71n7qVgnDnK29wnLhHDat9rkC62CIbonpkVY
+mnReX0jze+7twRanJOMCJ+lFg16BDvBcG8u0n/wIDkHHitBI7bU1k6c6DydLQ+69
+h8SCo6sO9YuD+/3xAGKad4ImZ6vTwlB4zDCpu6YgQWocWRXE+VkOb+RBfvP755PU
+aLfL63AFVlpOnEpIio5++UjNJRuPuAA=
+                    </ds:X509Certificate>
+                </ds:X509Data>
+            </ds:KeyInfo>
+            <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc">
+                <xenc:KeySize xmlns:xenc="http://www.w3.org/2001/04/xmlenc#">128</xenc:KeySize>
+</EncryptionMethod>
+        </KeyDescriptor>
+        <ArtifactResolutionService index="0" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.ssocircle.com:443/sso/ArtifactResolver/metaAlias/publicidp"/>
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.ssocircle.com:443/sso/IDPSloRedirect/metaAlias/publicidp" ResponseLocation="https://idp.ssocircle.com:443/sso/IDPSloRedirect/metaAlias/publicidp"/>
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.ssocircle.com:443/sso/IDPSloPost/metaAlias/publicidp" ResponseLocation="https://idp.ssocircle.com:443/sso/IDPSloPost/metaAlias/publicidp"/>
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.ssocircle.com:443/sso/IDPSloSoap/metaAlias/publicidp"/>
+        <ManageNameIDService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.ssocircle.com:443/sso/IDPMniRedirect/metaAlias/publicidp" ResponseLocation="https://idp.ssocircle.com:443/sso/IDPMniRedirect/metaAlias/publicidp"/>
+        <ManageNameIDService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.ssocircle.com:443/sso/IDPMniPOST/metaAlias/publicidp" ResponseLocation="https://idp.ssocircle.com:443/sso/IDPMniPOST/metaAlias/publicidp"/>
+        <ManageNameIDService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.ssocircle.com:443/sso/IDPMniSoap/metaAlias/publicidp"/>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+        <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos</NameIDFormat>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.ssocircle.com:443/sso/SSORedirect/metaAlias/publicidp"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.ssocircle.com:443/sso/SSOPOST/metaAlias/publicidp"/>
+        <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.ssocircle.com:443/sso/SSOSoap/metaAlias/publicidp"/>
+        <NameIDMappingService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://idp.ssocircle.com:443/sso/NIMSoap/metaAlias/publicidp"/>
+    </IDPSSODescriptor>
+</EntityDescriptor>


### PR DESCRIPTION
## Purpose
`permissionsRequired` is a required field now, so ensure that all endpoints have this defined, even if it's an empty set.

See [MODLOGSAML-60](https://issues.folio.org/browse/MODLOGSAML-60)