### PR TITLE
MODLOGSAML-62 - Release v2.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+## 2.0.0 - Released
+
+This is a maintenance release focused on keeping dependencies up to date.  The major version change is due to the new permission requirements on APIs which were previously unrestricted.
+ 
+[Full Changelog](https://github.com/folio-org/mod-login-saml/compare/v1.3.0...v2.0.0)
+ 
+### Stories
+ * [MODLOGSAML-64](https://issues.folio.org/browse/MODLOGSAML-64) - Upgrade to RMB v30
+ * [MODLOGSAML-60](https://issues.folio.org/browse/MODLOGSAML-60) - Securing APIs by default
+
+### Bugs
+ * [MODLOGSAML-55](https://issues.folio.org/browse/MODLOGSAML-55) - org.pac4j:pac4j-saml vulnerability found in pom.xml on Nov 6, 2019
+
 ## 1.3.0 2020-03-13
  * Rely on RMB's vertx. dependencies - in particular the Postgres driver
    which has been using specific versions with session usage fix

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,21 +3,21 @@
 ## 2.0.0 - 2020-06-09
 
 This is a maintenance release focused on keeping dependencies up to date.  The major version change is due to the new permission requirements on APIs which were previously unrestricted.
- 
+
 [Full Changelog](https://github.com/folio-org/mod-login-saml/compare/v1.3.0...v2.0.0)
- 
+
 ### Stories
  * [MODLOGSAML-64](https://issues.folio.org/browse/MODLOGSAML-64) - Upgrade to RMB v30
  * [MODLOGSAML-60](https://issues.folio.org/browse/MODLOGSAML-60) - Securing APIs by default
 
-## 1.3.0 2020-03-13
+## 1.3.0 - 2020-03-13
  * Rely on RMB's vertx. dependencies - in particular the Postgres driver
    which has been using specific versions with session usage fix
  * Update to RMB 29.3.1 (#55)
  * MODLOGSAML-53 Use JVM features to manage container memory
  * MODLOGSAML-51 Fix com.fasterxml.jackson.core:jackson-databind vulnerability
 
-## 1.2.2 2019-08-01
+## 1.2.2 - 2019-08-01
  * MODLOGSAML-45 Fix security vulnerabilities reported in
    jackson-databind >= 2.0.0, < 2.9.9.1
  * MODLOGSAML-40 api fails to validate idpurl if the content type

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 2.0.0 - Released
+## 2.1.0 - Unreleased
+
+## 2.0.0 - 2020-06-09
 
 This is a maintenance release focused on keeping dependencies up to date.  The major version change is due to the new permission requirements on APIs which were previously unrestricted.
  

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,6 @@ This is a maintenance release focused on keeping dependencies up to date.  The m
  * [MODLOGSAML-64](https://issues.folio.org/browse/MODLOGSAML-64) - Upgrade to RMB v30
  * [MODLOGSAML-60](https://issues.folio.org/browse/MODLOGSAML-60) - Securing APIs by default
 
-### Bugs
- * [MODLOGSAML-55](https://issues.folio.org/browse/MODLOGSAML-55) - org.pac4j:pac4j-saml vulnerability found in pom.xml on Nov 6, 2019
-
 ## 1.3.0 2020-03-13
  * Rely on RMB's vertx. dependencies - in particular the Postgres driver
    which has been using specific versions with session usage fix

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-login-saml</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <name>mod-login-saml</name>
 
   <licenses>
@@ -133,7 +133,7 @@
     <url>https://github.com/folio-org/mod-login-saml</url>
     <connection>scm:git:git://github.com:folio-org/mod-login-saml.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-login-saml.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.0</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-login-saml</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>mod-login-saml</name>
 
   <licenses>
@@ -133,7 +133,7 @@
     <url>https://github.com/folio-org/mod-login-saml</url>
     <connection>scm:git:git://github.com:folio-org/mod-login-saml.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-login-saml.git</developerConnection>
-    <tag>v2.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
Release v2.0.0.

The major version bump is due to new permission requirements on APIs which were previously unrestricted.

See:  https://issues.folio.org/browse/MODLOGSAML-62