### PR TITLE
MODLOGSAML-63 & MODLOGSAML-58 - Prevent CSRF and Arbitrary Redirect

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -8,20 +8,22 @@
       "handlers": [
         {
           "methods": [
-            "POST"
+            "POST", "OPTIONS"
           ],
           "pathPattern": "/saml/login",
           "permissionsRequired": [],
+          "delegateCORS": true,
           "modulePermissions": [
             "configuration.entries.collection.get"
           ]
         },
         {
           "methods": [
-            "POST"
+            "POST", "OPTIONS"
           ],
           "pathPattern": "/saml/callback",
           "permissionsRequired": [],
+          "delegateCORS": true,
           "modulePermissions": [
             "auth.signtoken",
             "configuration.entries.collection.get",

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <folio.domain-models-runtime.version>30.0.1</folio.domain-models-runtime.version>
+    <folio.domain-models-runtime.version>30.2.4</folio.domain-models-runtime.version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 

--- a/ramls/saml-login.raml
+++ b/ramls/saml-login.raml
@@ -47,6 +47,19 @@ types:
           body:
             text/plain:
               example: "Internal server error"
+    options:
+      description: "Preflight CORS for /saml/login"
+      headers:
+        Origin:
+          required: true
+      responses:
+        200:
+          description: "Return with appropriate CORS headers"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
   /callback:
     post:
       description: Redirect browser to sso-landing page with generated token.
@@ -74,6 +87,19 @@ types:
           body:
             text/plain:
               example: "Forbidden"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
+    options:
+      description: "Preflight CORS for /saml/callback"
+      headers:
+        Origin:
+          required: true
+      responses:
+        200:
+          description: "Return with appropriate CORS headers"
         500:
           description: "Internal server error"
           body:

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -49,8 +49,11 @@ public class SamlClientLoader {
     OkapiHeaders okapiHeaders = OkapiHelper.okapiHeaders(routingContext);
     final String tenantId = okapiHeaders.getTenant();
 
-    ConfigurationsClient.getConfiguration(okapiHeaders)
-      .compose(samlConfiguration -> {
+    ConfigurationsClient.getConfiguration(okapiHeaders).onComplete(ar -> {
+      if(ar.failed()) {
+        result.fail(ar.cause());
+      } else {
+        SamlConfiguration samlConfiguration = ar.result();
 
         final Promise<SamlClientComposite> clientInstantiationFuture = Promise.promise();
 
@@ -135,11 +138,9 @@ public class SamlClientLoader {
             });
           }
         }
-
-
         clientInstantiationFuture.future().onComplete(result.future()::handle);
-        return result.future();
-      });
+      }
+    });
 
     return result.future();
   }

--- a/src/main/java/org/folio/config/model/SamlClientComposite.java
+++ b/src/main/java/org/folio/config/model/SamlClientComposite.java
@@ -1,5 +1,6 @@
 package org.folio.config.model;
 
+import org.folio.util.CorsHelper;
 import org.pac4j.saml.client.SAML2Client;
 import org.springframework.util.Assert;
 
@@ -10,12 +11,14 @@ public class SamlClientComposite {
 
   private final SAML2Client client;
   private final SamlConfiguration configuration;
+  private final CorsHelper corsHelper;
 
   public SamlClientComposite(SAML2Client client, SamlConfiguration configuration) {
     Assert.notNull(client, "Client cannot be null!");
     Assert.notNull(configuration, "Configuration cannot be null!");
     this.client = client;
     this.configuration = configuration;
+    this.corsHelper = new CorsHelper(configuration);
   }
 
   public SAML2Client getClient() {
@@ -24,5 +27,9 @@ public class SamlClientComposite {
 
   public SamlConfiguration getConfiguration() {
     return configuration;
+  }
+
+  public CorsHelper getCorsHelper() {
+    return corsHelper;
   }
 }

--- a/src/main/java/org/folio/config/model/SamlConfiguration.java
+++ b/src/main/java/org/folio/config/model/SamlConfiguration.java
@@ -1,7 +1,12 @@
 package org.folio.config.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.vertx.core.json.JsonArray;
 
 /**
  * POJO for strongly typed configuration client
@@ -20,6 +25,7 @@ public class SamlConfiguration {
   public static final String USER_PROPERTY_CODE = "user.property";
   public static final String METADATA_INVALIDATED_CODE = "metadata.invalidated";
   public static final String OKAPI_URL= "okapi.url";
+  public static final String CORS_ALLOWABLE_ORIGINS = "cors.allowable.origins";
 
   @JsonProperty(IDP_URL_CODE)
   private String idpUrl;
@@ -38,10 +44,10 @@ public class SamlConfiguration {
   @JsonProperty(METADATA_INVALIDATED_CODE)
   private String metadataInvalidated = "true";
 
-
   @JsonProperty(OKAPI_URL)
   private String okapiUrl;
-
+  @JsonProperty(CORS_ALLOWABLE_ORIGINS)
+  private List<String> corsAllowableOrigins = new ArrayList<>();
 
   public String getIdpUrl() {
     return idpUrl;
@@ -106,11 +112,20 @@ public class SamlConfiguration {
   public void setMetadataInvalidated(String metadataInvalidated) {
     this.metadataInvalidated = metadataInvalidated;
   }
+
   public String getOkapiUrl() {
     return okapiUrl;
   }
 
   public void setOkapiUrl(String okapiUrl) {
     this.okapiUrl = okapiUrl;
+  }
+
+  public List<String> getCorsAllowableOrigins() {
+    return corsAllowableOrigins;
+  }
+
+  public void setCorsAllowableOrigins(String corsAllowableOrigins) {
+    new JsonArray(corsAllowableOrigins).forEach(o -> this.corsAllowableOrigins.add(o.toString()));
   }
 }

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -648,6 +648,6 @@ public class SamlAPI implements Saml {
     if(csrfTokenCookie == null) {
       return false;
     }
-    return relayStateUrl.getQuery().contains("csrfToken="+csrfTokenCookie.getValue()) ? true : false;
+    return relayStateUrl.getQuery().contains("csrfToken="+csrfTokenCookie.getValue());
   }
 }

--- a/src/main/java/org/folio/util/CorsHandlerImpl.java
+++ b/src/main/java/org/folio/util/CorsHandlerImpl.java
@@ -1,0 +1,180 @@
+package org.folio.util;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.handler.CorsHandler;
+import io.vertx.ext.web.RoutingContext;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static io.vertx.core.http.HttpHeaders.*;
+
+/**
+ * Based partially on original authored by David Dossot
+ * @author <a href="david@dossot.net">David Dossot</a>
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class CorsHandlerImpl implements CorsHandler {
+
+  private final Pattern allowedOrigin;
+
+  private String allowedMethodsString;
+  private String allowedHeadersString;
+  private String exposedHeadersString;
+  private boolean allowCredentials;
+  private String maxAgeSeconds;
+  private final Set<HttpMethod> allowedMethods = new LinkedHashSet<>();
+  private final Set<String> allowedHeaders = new LinkedHashSet<>();
+  private final Set<String> exposedHeaders = new LinkedHashSet<>();
+
+  public CorsHandlerImpl(String allowedOriginPattern) {
+    Objects.requireNonNull(allowedOriginPattern);
+    if ("*".equals(allowedOriginPattern)) {
+      allowedOrigin = null;
+    } else {
+      allowedOrigin = Pattern.compile(allowedOriginPattern);
+    }
+  }
+
+  @Override
+  public CorsHandler allowedMethod(HttpMethod method) {
+    allowedMethods.add(method);
+    allowedMethodsString = join(allowedMethods);
+    return this;
+  }
+
+  @Override
+  public CorsHandler allowedMethods(Set<HttpMethod> methods) {
+    allowedMethods.addAll(methods);
+    allowedMethodsString = join(allowedMethods);
+    return this;
+  }
+
+  @Override
+  public CorsHandler allowedHeader(String headerName) {
+    allowedHeaders.add(headerName);
+    allowedHeadersString = join(allowedHeaders);
+    return this;
+  }
+
+  @Override
+  public CorsHandler allowedHeaders(Set<String> headerNames) {
+    allowedHeaders.addAll(headerNames);
+    allowedHeadersString = join(allowedHeaders);
+    return this;
+  }
+
+  @Override
+  public CorsHandler exposedHeader(String headerName) {
+    exposedHeaders.add(headerName);
+    exposedHeadersString = join(exposedHeaders);
+    return this;
+  }
+
+  @Override
+  public CorsHandler exposedHeaders(Set<String> headerNames) {
+    exposedHeaders.addAll(headerNames);
+    exposedHeadersString = join(exposedHeaders);
+    return this;
+  }
+
+  @Override
+  public CorsHandler allowCredentials(boolean allow) {
+    if (allowedOrigin == null && allow) {
+      // https://developer.mozilla.org/En/HTTP_access_control#Requests_with_credentials
+      throw new IllegalStateException("wildcard origin with credentials is not allowed");
+    }
+    this.allowCredentials = allow;
+    return this;
+  }
+
+  @Override
+  public CorsHandler maxAgeSeconds(int maxAgeSeconds) {
+    this.maxAgeSeconds = maxAgeSeconds == -1 ? null : String.valueOf(maxAgeSeconds);
+    return this;
+  }
+
+  @Override
+  public void handle(RoutingContext context) {
+    HttpServerRequest request = context.request();
+    HttpServerResponse response = context.response();
+    String origin = context.request().headers().get(ORIGIN);
+    if (origin == null) {
+      // Not a CORS request - we don't set any headers and just call the next handler
+    } else if (isValidOrigin(origin)) {
+      String accessControlRequestMethod = request.headers().get(ACCESS_CONTROL_REQUEST_METHOD);
+      if (request.method() == HttpMethod.OPTIONS && accessControlRequestMethod != null) {
+        // Pre-flight request
+        addCredentialsAndOriginHeader(response, origin);
+        if (allowedMethodsString != null) {
+          response.putHeader(ACCESS_CONTROL_ALLOW_METHODS, allowedMethodsString);
+        }
+        if (allowedHeadersString != null) {
+          response.putHeader(ACCESS_CONTROL_ALLOW_HEADERS, allowedHeadersString);
+        }
+        if (maxAgeSeconds != null) {
+          response.putHeader(ACCESS_CONTROL_MAX_AGE, maxAgeSeconds);
+        }
+        // according to MDC although the is no body the response should be OK
+        response.setStatusCode(200).end();
+      } else {
+        addCredentialsAndOriginHeader(response, origin);
+        if (exposedHeadersString != null) {
+          response.putHeader(ACCESS_CONTROL_EXPOSE_HEADERS, exposedHeadersString);
+        }
+      }
+    } else {
+      context
+        .response()
+        .setStatusMessage("CORS Rejected - Invalid origin");
+      context
+        .fail(403);
+    }
+  }
+
+  private void addCredentialsAndOriginHeader(HttpServerResponse response, String origin) {
+    if (allowCredentials) {
+      response.putHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+      // Must be exact origin (not '*') in case of credentials
+      response.putHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+    } else {
+      // Can be '*' too
+      response.putHeader(ACCESS_CONTROL_ALLOW_ORIGIN, getAllowedOrigin(origin));
+    }
+  }
+
+  private boolean isValidOrigin(String origin) {
+    if (allowedOrigin == null) {
+      // Null means accept all origins
+      return true;
+    }
+    return allowedOrigin.matcher(origin).matches();
+  }
+
+  private String getAllowedOrigin(String origin) {
+    return allowedOrigin == null ? "*" : origin;
+  }
+
+  private String join(Collection<?> ss) {
+    if (ss == null || ss.isEmpty()) {
+      return null;
+    }
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (Object s : ss) {
+      if (!first) {
+        sb.append(',');
+      }
+      sb.append(s);
+      first = false;
+    }
+    return sb.toString();
+  }
+
+}
+

--- a/src/main/java/org/folio/util/CorsHelper.java
+++ b/src/main/java/org/folio/util/CorsHelper.java
@@ -18,14 +18,14 @@ import io.vertx.ext.web.handler.CorsHandler;
 public class CorsHelper {
   private static final Logger log = LoggerFactory.getLogger(CorsHelper.class.getName());
 
-  private static final String REGEX_PREFIX = "http[s]?://";
-  private CorsHandler handler;
+  protected static final String REGEX_PREFIX = "http[s]?://(";
+  protected CorsHandler handler;
 
   public CorsHelper(SamlConfiguration configuration) {
     Assert.notNull(configuration, "Configuration cannot be null!");
 
     String allowableOrigins = formAllowedOriginRegex(configuration.getCorsAllowableOrigins());
-    if (allowableOrigins.equals(REGEX_PREFIX)) {
+    if (allowableOrigins.equals(REGEX_PREFIX + ")")) {
       log.warn("No Allowable Origins were configured");
     } else {
       log.info("Allowable Origins: {}", allowableOrigins);
@@ -50,7 +50,7 @@ public class CorsHelper {
     }
   }
 
-  protected String formAllowedOriginRegex(List<String> allowed) {
+  protected static String formAllowedOriginRegex(List<String> allowed) {
     StringBuilder sb = new StringBuilder();
     sb.append(REGEX_PREFIX);
     boolean appendPipe = false;
@@ -61,15 +61,18 @@ public class CorsHelper {
           sb.append("|");
         }
         int port = url.getPort();
-        sb.append("(")
-          .append(url.getHost())
-          .append((port > 0 ? ":" + port : ""))
-          .append(")");
+        sb.append(url.getHost());
+
+        if (port > 0) {
+          sb.append(":")
+            .append(port);
+        }
         appendPipe = true;
       } catch (MalformedURLException e) {
         log.warn("Invalid URL for origin: {}", originStr, e);
       }
     }
+    sb.append(")");
     return sb.toString();
   }
 

--- a/src/main/java/org/folio/util/CorsHelper.java
+++ b/src/main/java/org/folio/util/CorsHelper.java
@@ -33,7 +33,7 @@ public class CorsHelper {
           sb.append("|");
         }
         sb.append("(")
-          .append(url.getHost())
+          .append(url.getHost() + (url.getPort() != 80 && url.getPort() != 443 ? ":" + url.getPort() : ""))
           .append(")");
         appendPipe = true;
       } catch (MalformedURLException e) {
@@ -47,7 +47,7 @@ public class CorsHelper {
     } else {
       log.info("Allowable Origins: {}", allowableOrigins);
 
-      this.handler = CorsHandler.create(allowableOrigins)
+      this.handler = new CorsHandlerImpl(allowableOrigins)
         .allowedMethod(HttpMethod.PUT)
         .allowedMethod(HttpMethod.GET)
         .allowedMethod(HttpMethod.POST)

--- a/src/main/java/org/folio/util/CorsHelper.java
+++ b/src/main/java/org/folio/util/CorsHelper.java
@@ -1,0 +1,77 @@
+package org.folio.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.folio.config.model.SamlConfiguration;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.Assert;
+
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.CorsHandler;
+
+public class CorsHelper {
+  private static final Logger log = LoggerFactory.getLogger(CorsHelper.class.getName());
+
+  private static final String REGEX_PREFIX = "http[s]?://";
+  private CorsHandler handler;
+
+  public CorsHelper(SamlConfiguration configuration) {
+    Assert.notNull(configuration, "Configuration cannot be null!");
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(REGEX_PREFIX);
+    boolean appendPipe = false;
+    for (String originStr : configuration.getCorsAllowableOrigins()) {
+      try {
+        URL url = new URL(originStr);
+        if (appendPipe) {
+          sb.append("|");
+        }
+        sb.append("(")
+          .append(url.getHost())
+          .append(")");
+        appendPipe = true;
+      } catch (MalformedURLException e) {
+        log.warn("Invalid URL for origin: {}", originStr, e);
+      }
+    }
+
+    String allowableOrigins = sb.toString();
+    if (allowableOrigins.equals(REGEX_PREFIX)) {
+      log.warn("No Allowable Origins were configured");
+    } else {
+      log.info("Allowable Origins: {}", allowableOrigins);
+
+      this.handler = CorsHandler.create(allowableOrigins)
+        .allowedMethod(HttpMethod.PUT)
+        .allowedMethod(HttpMethod.GET)
+        .allowedMethod(HttpMethod.POST)
+        .allowedHeader(HttpHeaders.CONTENT_TYPE.toString())
+        .allowedHeader(XOkapiHeaders.TENANT)
+        .allowedHeader(XOkapiHeaders.TOKEN)
+        .allowedHeader(XOkapiHeaders.AUTHORIZATION)
+        .allowedHeader(XOkapiHeaders.REQUEST_ID) // expose response headers
+        .allowedHeader(XOkapiHeaders.MODULE_ID)
+        .allowCredentials(true)
+        .exposedHeader(HttpHeaders.LOCATION.toString())
+        .exposedHeader(XOkapiHeaders.TRACE)
+        .exposedHeader(XOkapiHeaders.TOKEN)
+        .exposedHeader(XOkapiHeaders.AUTHORIZATION)
+        .exposedHeader(XOkapiHeaders.REQUEST_ID)
+        .exposedHeader(XOkapiHeaders.MODULE_ID);
+    }
+  }
+
+  public void handle(RoutingContext routingContext) {
+    if (handler == null) {
+      routingContext.next();
+    } else {
+      handler.handle(routingContext);
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -5,16 +5,16 @@ import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInC
 import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
 
+import org.folio.config.SamlConfigHolder;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.SamlConfigRequest;
-import org.folio.rest.tools.client.HttpClientFactory;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.util.IdpMock;
@@ -25,17 +25,20 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.w3c.dom.ls.LSResourceResolver;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
@@ -46,10 +49,15 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class SamlAPITest {
   private static final Logger log = LoggerFactory.getLogger(SamlAPITest.class);
 
-  private static final Header TENANT_HEADER = new Header("X-Okapi-Tenant", "saml-test");
-  private static final Header TOKEN_HEADER = new Header("X-Okapi-Token", "saml-test");
+  private static final String TENANT = "saml-test";
+  private static final Header TENANT_HEADER = new Header("X-Okapi-Tenant", TENANT);
+  private static final Header TOKEN_HEADER = new Header("X-Okapi-Token", TENANT);
   private static final Header OKAPI_URL_HEADER = new Header("X-Okapi-Url", "http://localhost:9130");
   private static final Header JSON_CONTENT_TYPE_HEADER = new Header("Content-Type", "application/json");
+  private static final Header ACCESS_CONTROL_REQ_HEADERS_HEADER = new Header(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS.toString(),
+      "content-type,x-okapi-tenant,x-okapi-token");
+  private static final Header ACCESS_CONTROL_REQUEST_METHOD_HEADER = new Header(
+      HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD.toString(), "POST");
   private static final String STRIPES_URL = "http://localhost:3000";
 
   public static final int PORT = 8081;
@@ -81,7 +89,7 @@ public class SamlAPITest {
     RestAssured.port = PORT;
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
-    mock = new HttpClientMock2("http://localhost:9130", "saml-test");
+    mock = new HttpClientMock2("http://localhost:9130", TENANT);
     mock.setMockJsonContent("mock_content.json");
 
     vertx.deployVerticle(new RestVerticle(), options, context.asyncAssertSuccess());
@@ -89,6 +97,9 @@ public class SamlAPITest {
 
   @After
   public void tearDown(TestContext context) throws Exception {
+    // Need to clear singleton to maintain test/order independence
+    SamlConfigHolder.getInstance().removeClient(TENANT);
+
     vertx.close(context.asyncAssertSuccess());
   }
 
@@ -134,7 +145,7 @@ public class SamlAPITest {
       .statusCode(400);
 
     // good
-    given()
+    ExtractableResponse<Response> resp = given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
       .header(OKAPI_URL_HEADER)
@@ -142,17 +153,148 @@ public class SamlAPITest {
       .body("{\"stripesUrl\":\"" + STRIPES_URL + "\"}")
       .post("/saml/login")
       .then()
+      .log().all()
       .contentType(ContentType.JSON)
       .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlLogin.json"))
       .body("bindingMethod", equalTo("POST"))
-      .body("relayState", equalTo(STRIPES_URL))
-      .statusCode(200);
+      .statusCode(200)
+      .extract();
+
+    String csrfToken = resp.cookie("csrfToken");
+    String relayState = resp.body().jsonPath().getString("relayState");
+    assertEquals(STRIPES_URL+"?csrfToken="+csrfToken, relayState);
+
+    // stripesUrl w/ query args
+    resp = given()
+        .header(TENANT_HEADER)
+        .header(TOKEN_HEADER)
+        .header(OKAPI_URL_HEADER)
+        .header(JSON_CONTENT_TYPE_HEADER)
+        .body("{\"stripesUrl\":\"" + STRIPES_URL + "?foo=bar\"}")
+        .post("/saml/login")
+        .then()
+        .log().all()
+        .contentType(ContentType.JSON)
+        .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlLogin.json"))
+        .body("bindingMethod", equalTo("POST"))
+        .statusCode(200)
+        .extract();
+
+      csrfToken = resp.cookie("csrfToken");
+      relayState = resp.body().jsonPath().getString("relayState");
+      assertEquals(STRIPES_URL+"?foo=bar&csrfToken="+csrfToken, relayState);
+  }
+
+  @Test
+  public void loginCorsTests() throws IOException {
+    String origin = "http://localhost";
+
+    log.info("=== Test CORS preflight - OPTIONS /saml/login - success ===");
+    given()
+      .header(new Header(HttpHeaders.ORIGIN.toString(), origin))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/login")
+      .then()
+      .log()
+      .all()
+      .statusCode(200)
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), equalTo(origin))
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), equalTo("true"));
+
+    log.info("=== Test CORS preflight - OPTIONS /saml/login - failure - no origin ===");
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/login")
+      .then()
+      .log()
+      .all()
+      .statusCode(404);
+
+    log.info("=== Test CORS preflight OPTIONS /saml/login - failure - bad origin ===");
+    given()
+      .header(new Header(HttpHeaders.ORIGIN.toString(), "http://anotherhost.com"))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/login")
+      .then()
+      .log()
+      .all()
+      .statusCode(403);
+  }
+
+  @Test
+  public void corsNotConfiguredTests() throws IOException {
+    String origin = "http://localhost";
+
+    mock.setMockJsonContent("no_cors.json");
+
+    log.info("=== Test CORS preflight - OPTIONS /saml/login - no allowable origins configured ===");
+    given()
+      .header(new Header(HttpHeaders.ORIGIN.toString(), origin))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/login")
+      .then()
+      .log()
+      .all()
+      .body(equalTo("Internal Server Error"))
+      .statusCode(500); 
+
+    mock.setMockJsonContent("with_invalid_origins.json");
+    SamlConfigHolder.getInstance().removeClient(TENANT);
+
+    log.info("=== Test CORS preflight - OPTIONS /saml/login - invalid allowable origins configured ===");
+    given()
+      .header(new Header(HttpHeaders.ORIGIN.toString(), origin))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/login")
+      .then()
+      .log()
+      .all()
+      .statusCode(404);
+  }
+
+  @Test
+  public void callbackCorsTests() throws IOException {
+    String origin = "http://localhost";
+
+    log.info("=== Test CORS preflight - OPTIONS /saml/callback - success ===");
+    given()
+      .header(new Header(HttpHeaders.ORIGIN.toString(), origin))
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(ACCESS_CONTROL_REQ_HEADERS_HEADER)
+      .header(ACCESS_CONTROL_REQUEST_METHOD_HEADER)
+      .options("/saml/callback")
+      .then()
+      .log()
+      .all()
+      .statusCode(200)
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), equalTo(origin))
+      .header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), equalTo("true"));
   }
 
   @Test
   public void regenerateEndpointTests() throws IOException {
-
-
     LSResourceResolver resolver = new TestingClasspathResolver("schemas/");
 
     String metadata = given()
@@ -207,23 +349,54 @@ public class SamlAPITest {
 
   @Test
   public void callbackEndpointTests() throws IOException {
-
-
     final String testPath = "/test/path";
 
+    log.info("=== Setup - POST /saml/login - need relayState and csrfToken cookie ===");
+    ExtractableResponse<Response> resp = given()
+        .header(TENANT_HEADER)
+        .header(TOKEN_HEADER)
+        .header(OKAPI_URL_HEADER)
+        .header(JSON_CONTENT_TYPE_HEADER)
+        .body("{\"stripesUrl\":\"" + STRIPES_URL + testPath + "\"}")
+        .post("/saml/login")
+        .then()
+        .contentType(ContentType.JSON)
+        .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlLogin.json"))
+        .statusCode(200)
+        .extract();
+
+    String csrfToken = resp.cookie("csrfToken");
+    String relayState = resp.body()
+      .jsonPath()
+      .getString("relayState");
+
+    log.info("=== Test - POST /saml/callback - success ===");
     given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
       .header(OKAPI_URL_HEADER)
+      .cookie("csrfToken", csrfToken)
       .formParam("SAMLResponse", "saml-response")
-      .formParam("RelayState", STRIPES_URL + testPath)
+      .formParam("RelayState", relayState)
       .post("/saml/callback")
       .then()
+      .log().all()
       .statusCode(302)
       .header("Location", containsString(URLEncoder.encode(testPath, "UTF-8")))
       .header("x-okapi-token", "saml-token")
       .cookie("ssoToken", "saml-token");
 
+    log.info("=== Test - POST /saml/callback - failure (no CSRF token cookie) ===");
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .formParam("SAMLResponse", "saml-response")
+      .formParam("RelayState", relayState)
+      .post("/saml/callback")
+      .then()
+      .log().all()
+      .statusCode(403);
   }
 
   @Test

--- a/src/test/java/org/folio/util/CorsHelperTest.java
+++ b/src/test/java/org/folio/util/CorsHelperTest.java
@@ -1,0 +1,73 @@
+package org.folio.util;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.folio.config.model.SamlConfiguration;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+
+public class CorsHelperTest {
+
+  @Test
+  public void testConstructor() {
+    SamlConfiguration conf = new SamlConfiguration();
+    conf.setCorsAllowableOrigins("[]");
+    
+    assertNull(new CorsHelper(conf).handler);
+    
+    conf.setCorsAllowableOrigins(new JsonArray().add("http://localhost").encode());
+    
+    assertNotNull(new CorsHelper(conf).handler);
+  }
+  
+  @Test
+  public void testFormAllowedOriginRegex() {
+    List<String> allowed = new ArrayList<>();
+    String regex = CorsHelper.formAllowedOriginRegex(allowed);
+
+    assertEquals(CorsHelper.REGEX_PREFIX + ")", regex);
+    assertFalse(Pattern.matches(regex, "http://localhost"));
+
+    allowed.add("bogus");
+    regex = CorsHelper.formAllowedOriginRegex(allowed);
+
+    assertEquals(CorsHelper.REGEX_PREFIX + ")", regex);
+    assertFalse(Pattern.matches(regex, "http://localhost"));
+    
+    allowed.add("http://localhost");
+    regex = CorsHelper.formAllowedOriginRegex(allowed);
+
+    assertEquals(CorsHelper.REGEX_PREFIX + "localhost)", regex);
+    assertTrue(Pattern.matches(regex, "http://localhost"));
+    assertTrue(Pattern.matches(regex, "https://localhost"));
+    assertFalse(Pattern.matches(regex, "http://localhost:3000"));
+
+    allowed.add("https://idp.foo.com");
+    regex = CorsHelper.formAllowedOriginRegex(allowed);
+
+    assertEquals(CorsHelper.REGEX_PREFIX + "localhost|idp.foo.com)", regex);
+    assertTrue(Pattern.matches(regex, "http://localhost"));
+    assertTrue(Pattern.matches(regex, "https://localhost"));
+    assertTrue(Pattern.matches(regex, "http://idp.foo.com"));
+    assertTrue(Pattern.matches(regex, "https://idp.foo.com"));
+    assertFalse(Pattern.matches(regex, "http://localhost:3000"));
+
+    allowed.add("http://localhost:3000");
+    regex = CorsHelper.formAllowedOriginRegex(allowed);
+
+    assertEquals(CorsHelper.REGEX_PREFIX + "localhost|idp.foo.com|localhost:3000)", regex);
+    assertTrue(Pattern.matches(regex, "http://localhost"));
+    assertTrue(Pattern.matches(regex, "https://localhost"));
+    assertTrue(Pattern.matches(regex, "http://idp.foo.com"));
+    assertTrue(Pattern.matches(regex, "https://idp.foo.com"));
+    assertTrue(Pattern.matches(regex, "http://localhost:3000"));
+    assertTrue(Pattern.matches(regex, "https://localhost:3000"));
+    assertFalse(Pattern.matches(regex, "http://zippity.zap"));
+  }
+
+}

--- a/src/test/resources/no_cors.json
+++ b/src/test/resources/no_cors.json
@@ -7,13 +7,6 @@
       "receivedData": {
         "configs": [
           {
-            "id": "60eead4f-de97-437c-9cb7-09966ce50e49",
-            "module": "LOGIN-SAML",
-            "configName": "saml",
-            "code": "idp.url",
-            "value": "https://idp.ssocircle.com"
-          },
-          {
             "id": "022d8342-fa51-44d1-8b2b-27da36e11f07",
             "module": "LOGIN-SAML",
             "configName": "saml",
@@ -54,17 +47,10 @@
             "configName": "saml",
             "code": "okapi.url",
             "value": "http://localhost:9130"
-          },
-          {
-            "id": "1928eb9c-75c8-4d89-b1a3-3ccf02b3e70a",
-            "module": "LOGIN-SAML",
-            "configName": "saml",
-            "code": "cors.allowable.origins",
-            "value": "[\"http://localhost\",\"https://idp.ssocircle.com\"]"
           }
 
         ],
-        "totalRecords": 7
+        "totalRecords": 6
       },
       "receivedPath": "",
       "sendData": {}

--- a/src/test/resources/with_invalid_origins.json
+++ b/src/test/resources/with_invalid_origins.json
@@ -60,7 +60,7 @@
             "module": "LOGIN-SAML",
             "configName": "saml",
             "code": "cors.allowable.origins",
-            "value": "[\"http://localhost\",\"https://idp.ssocircle.com\"]"
+            "value": "[\"*\"]"
           }
 
         ],


### PR DESCRIPTION
## Purpose
The PR addresses two security issues:
* Cross Site Request Forgery:  See [MODLOGSAML-63](https://issues.folio.org/browse/MODLOGSAML-63) and [MODLOGSAML-59](https://issues.folio.org/browse/MODLOGSAML-59) for more context
* Arbitrary URL Redirection:  See [MODLOGSAML-58](https://issues.folio.org/browse/MODLOGSAML-58)

## Approach
This approach work is outlined here:  https://wiki.folio.org/display/DD/SAML+CSRF+Prevention

At a high level:
* Implement CORS handling so we can support the setting of cookies
  * Explicit host being returned in the `Access-Control-Allow-Origin` header instead of `*`
  * Return `Access-Control-Allow-Credentials: true`
* Upon login, generate a CSRF token and set a cookie with the token.  Also include the token in RelayState that's sent and inculded in the callback made by the IdP unchanged0
* Upon callback, compare the CSRF Token from RelayState with the cookie value that the browser sends.  If they don't match, reject the call.
* In order to address the arbitrary url redirection issue, both the cookie and RelayState should contain not just the CSRF token, but also the redirect URL.  The whole thing (URL + CSRF token) can be compared, ensuring that it's A) the same client and B) that the redirect URL wasn't changed.

## TODO
* [ ] the module descriptor - Do I need to add the preflight OPTIONS endpoints here?  Need to give it a try.
 