### PR TITLE
MODLOGSAML-73: Upgrade raml-module-builder (RMB) to 30.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     </generate_routing_context>
 
     <pac4j.version>3.8.3</pac4j.version>
+    <rest-assured.version>4.3.1</rest-assured.version>
     <vertx-pac4j.version>4.1.1</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -83,14 +84,14 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.3.1</version>
+      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>4.3.1</version>
+      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <folio.domain-models-runtime.version>30.0.1</folio.domain-models-runtime.version>
+    <folio.domain-models-runtime.version>30.2.6</folio.domain-models-runtime.version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
@@ -83,14 +83,14 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.3</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>3.0.3</version>
+      <version>4.3.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -115,7 +115,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.1</version>
+        <version>3.9.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
We need to bump the rest-assured version otherwise it
introduces an old incompatible jopt-simple version.