### PR TITLE
MODLOGSAML-74: Release 2.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 ## 2.1.0 - Unreleased
 
+## 2.0.1 - 2020-08-28
+ * [MODLOGSAML-73](https://issues.folio.org/browse/MODLOGSAML-73) Upgrade raml-module-builder (RMB) from 30.0.1 to 30.2.6
+
 ## 2.0.0 - 2020-06-09
 
 This is a maintenance release focused on keeping dependencies up to date.  The major version change is due to the new permission requirements on APIs which were previously unrestricted.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-login-saml</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.1</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>mod-login-saml</name>
 
   <licenses>
@@ -144,7 +144,7 @@
     <url>https://github.com/folio-org/mod-login-saml</url>
     <connection>scm:git:git://github.com:folio-org/mod-login-saml.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-login-saml.git</developerConnection>
-    <tag>v2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-login-saml</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.0.1</version>
   <name>mod-login-saml</name>
 
   <licenses>
@@ -144,7 +144,7 @@
     <url>https://github.com/folio-org/mod-login-saml</url>
     <connection>scm:git:git://github.com:folio-org/mod-login-saml.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-login-saml.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v2.0.1</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
* [MODLOGSAML-73](https://issues.folio.org/browse/MODLOGSAML-73) Upgrade raml-module-builder (RMB) from 30.0.1 to 30.2.6