### PR TITLE
MODLOGSAML-67: pac4j-saml 4.1.0, Cryptacular 1.2.4 (CVE-2020-7226)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,18 +31,29 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <folio.domain-models-runtime.version>30.2.6</folio.domain-models-runtime.version>
+    <folio.domain-models-runtime.version>30.2.9</folio.domain-models-runtime.version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <pac4j.version>3.8.3</pac4j.version>
+    <pac4j.version>4.1.0</pac4j.version>
     <rest-assured.version>4.3.1</rest-assured.version>
-    <vertx-pac4j.version>4.1.1</vertx-pac4j.version>
+    <vertx-pac4j.version>5.0.0</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
 
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.9.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -71,7 +82,7 @@
 
     <dependency>
       <groupId>org.pac4j</groupId>
-      <artifactId>pac4j-saml</artifactId>
+      <artifactId>pac4j-saml-opensamlv3</artifactId>
       <version>${pac4j.version}</version>
     </dependency>
 
@@ -98,7 +109,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 
@@ -109,19 +120,6 @@
     </dependency>
 
   </dependencies>
-
-  <!-- Overriding versions coming from RMB -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.2</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <distributionManagement>
     <repository>
@@ -151,7 +149,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>${maven.compiler.source}</source>
           <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -45,14 +45,14 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
   @Override
   public Optional<RedirectionAction> getRedirectionAction(WebContext webContext) {
 
-    final SAML2MessageContext context = this.client.getContextProvider().buildContext(webContext);
-    final String relayState = this.client.getStateGenerator().generateValue(webContext);
-
-    final AuthnRequest authnRequest = this.saml2ObjectBuilder.build(context);
-    String destination = authnRequest.getDestination();
-
     try {
-      // Signtiture, etc.
+      final SAML2MessageContext context = this.client.getContextProvider().buildContext(webContext);
+      final String relayState = this.client.getStateGenerator().generateValue(webContext);
+
+      final AuthnRequest authnRequest = this.saml2ObjectBuilder.build(context);
+      String destination = authnRequest.getDestination();
+
+      // Signature, etc.
       this.client.getProfileHandler().send(context, authnRequest, relayState);
       final Pac4jSAMLResponse adapter = context.getProfileRequestContextOutboundMessageTransportResponse();
 

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -139,7 +139,8 @@ public class SamlClientLoader {
 
         clientInstantiationFuture.future().onComplete(result.future()::handle);
         return result.future();
-      });
+      })
+      .onFailure(result::tryFail);
 
     return result.future();
   }

--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -236,7 +236,7 @@ public class SamlClientLoader {
     SAML2Client saml2Client = mock ? new SAML2ClientMock(cfg) : new SAML2Client(cfg);
     saml2Client.setName(tenantId);
     saml2Client.setCallbackUrl(buildCallbackUrl(okapiUrl, tenantId));
-    saml2Client.setRedirectActionBuilder(new JsonReponseSaml2RedirectActionBuilder(saml2Client));
+    saml2Client.setRedirectionActionBuilder(new JsonReponseSaml2RedirectActionBuilder(saml2Client));
     saml2Client.setStateGenerator(new SAML2StateGenerator(saml2Client));
 
     return saml2Client;

--- a/src/main/java/org/folio/config/model/SAML2ClientMock.java
+++ b/src/main/java/org/folio/config/model/SAML2ClientMock.java
@@ -3,7 +3,7 @@ package org.folio.config.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
+import java.util.Optional;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.NameID;
@@ -28,7 +28,7 @@ public class SAML2ClientMock extends SAML2Client {
   }
 
   @Override
-  protected SAML2Credentials retrieveCredentials(WebContext context) {
+  protected Optional<SAML2Credentials> retrieveCredentials(WebContext context) {
     log.info("Mocking SAML2Client retrieveCredentials...");
 
     NameID nameId = new NameIDBuilder().buildObject();
@@ -41,7 +41,7 @@ public class SAML2ClientMock extends SAML2Client {
     CommonProfile userProfile = new CommonProfile();
     userProfile.addAttribute("UserID", Arrays.asList(SAML_USER_ID));
     cred.setUserProfile(userProfile);
-    return cred;
+    return Optional.of(cred);
   }
 
 }

--- a/src/main/java/org/folio/util/HttpActionMapper.java
+++ b/src/main/java/org/folio/util/HttpActionMapper.java
@@ -1,8 +1,7 @@
 package org.folio.util;
 
-import org.pac4j.core.exception.HttpAction;
-
 import javax.ws.rs.core.Response;
+import org.pac4j.core.exception.http.HttpAction;
 
 /**
  * @author rsass

--- a/src/main/java/org/folio/util/VertxUtils.java
+++ b/src/main/java/org/folio/util/VertxUtils.java
@@ -7,6 +7,7 @@ import org.pac4j.vertx.VertxWebContext;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.Session;
+import java.util.Optional;
 
 /**
  * Vert.x utils
@@ -41,8 +42,8 @@ public class VertxUtils {
     }
 
     @Override
-    public Object get(VertxWebContext context, String key) {
-      return session.get(key);
+    public Optional<Object> get(VertxWebContext context, String key) {
+      return Optional.ofNullable(session.get(key));
     }
 
     @Override
@@ -57,13 +58,13 @@ public class VertxUtils {
     }
 
     @Override
-    public Object getTrackableSession(VertxWebContext context) {
-      return session;
+    public Optional getTrackableSession(VertxWebContext context) {
+      return Optional.ofNullable(session);
     }
 
     @Override
-    public SessionStore<VertxWebContext> buildFromTrackableSession(VertxWebContext context, Object trackableSession) {
-      return new DummySessionStore(vertx, (Session) trackableSession);
+    public Optional<SessionStore<VertxWebContext>> buildFromTrackableSession(VertxWebContext context, Object trackableSession) {
+      return Optional.of(new DummySessionStore(vertx, (Session) trackableSession));
     }
 
     @Override

--- a/src/test/java/org/folio/config/JsonReponseSaml2RedirectActionBuilderTest.java
+++ b/src/test/java/org/folio/config/JsonReponseSaml2RedirectActionBuilderTest.java
@@ -11,9 +11,10 @@ public class JsonReponseSaml2RedirectActionBuilderTest {
 
   @Test
   public void statusAction500() {
+    JsonReponseSaml2RedirectActionBuilder builder =
+        new JsonReponseSaml2RedirectActionBuilder(mock(SAML2Client.class));
     Assert.assertEquals("Performing a 500 HTTP action", Assert.assertThrows(StatusAction.class, () ->
-      new JsonReponseSaml2RedirectActionBuilder(mock(SAML2Client.class))
-      .getRedirectionAction(null)).getMessage());
+      builder.getRedirectionAction(null)).getMessage());
   }
 
 }

--- a/src/test/java/org/folio/config/JsonReponseSaml2RedirectActionBuilderTest.java
+++ b/src/test/java/org/folio/config/JsonReponseSaml2RedirectActionBuilderTest.java
@@ -1,0 +1,19 @@
+package org.folio.config;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pac4j.core.exception.http.StatusAction;
+import org.pac4j.saml.client.SAML2Client;
+
+public class JsonReponseSaml2RedirectActionBuilderTest {
+
+  @Test
+  public void statusAction500() {
+    Assert.assertEquals("Performing a 500 HTTP action", Assert.assertThrows(StatusAction.class, () ->
+      new JsonReponseSaml2RedirectActionBuilder(mock(SAML2Client.class))
+      .getRedirectionAction(null)).getMessage());
+  }
+
+}

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -6,15 +6,13 @@ import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotEquals;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
-
+import java.util.Optional;
+import org.folio.config.SamlConfigHolder;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.SamlConfigRequest;
-import org.folio.rest.tools.client.HttpClientFactory;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.util.IdpMock;
@@ -25,8 +23,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.exception.http.TemporaryRedirectAction;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.w3c.dom.ls.LSResourceResolver;
 
 import io.restassured.RestAssured;
@@ -44,8 +45,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
  */
 @RunWith(VertxUnitRunner.class)
 public class SamlAPITest {
-  private static final Logger log = LoggerFactory.getLogger(SamlAPITest.class);
-
   private static final Header TENANT_HEADER = new Header("X-Okapi-Tenant", "saml-test");
   private static final Header TOKEN_HEADER = new Header("X-Okapi-Token", "saml-test");
   private static final Header OKAPI_URL_HEADER = new Header("X-Okapi-Url", "http://localhost:9130");
@@ -100,23 +99,34 @@ public class SamlAPITest {
   @Test
   public void checkEndpointTests() {
 
-
     // bad
     given()
       .get("/saml/check")
       .then()
       .statusCode(400);
 
-    // good
+    SamlConfigHolder.getInstance().removeClient("saml-test");
+
+    // missing OKAPI_URL_HEADER -> "active": false
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .get("/saml/check")
+      .then()
+      .statusCode(200)
+      .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlCheck.json"))
+      .body("active", equalTo(false));
+
+    // good -> "active": true
     given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
       .header(OKAPI_URL_HEADER)
       .get("/saml/check")
       .then()
+      .statusCode(200)
       .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlCheck.json"))
-      .body("active", equalTo(Boolean.TRUE))
-      .statusCode(200);
+      .body("active", equalTo(true));
 
   }
 
@@ -147,6 +157,39 @@ public class SamlAPITest {
       .body("bindingMethod", equalTo("POST"))
       .body("relayState", equalTo(STRIPES_URL))
       .statusCode(200);
+
+    // AJAX 401
+    given()
+      .header(HttpConstants.AJAX_HEADER_NAME, HttpConstants.AJAX_HEADER_VALUE)
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .body("{\"stripesUrl\":\"" + STRIPES_URL + "\"}")
+      .post("/saml/login")
+      .then()
+      .statusCode(401);
+
+    // configure a wrong redirection action: TemporaryRedirectAction
+    RedirectionActionBuilder redirectionActionBuilder = new RedirectionActionBuilder() {
+      @Override
+      public Optional<RedirectionAction> getRedirectionAction(WebContext context) {
+        return Optional.of(new TemporaryRedirectAction("foo"));
+      }
+    };
+    SamlConfigHolder.getInstance().findClient("saml-test").getClient()
+    .setRedirectionActionBuilder(redirectionActionBuilder);
+
+    // 500 internal server error
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .body("{\"stripesUrl\":\"" + STRIPES_URL + "\"}")
+      .post("/saml/login")
+      .then()
+      .statusCode(500);
   }
 
   @Test

--- a/src/test/java/org/folio/util/VertxUtilsTest.java
+++ b/src/test/java/org/folio/util/VertxUtilsTest.java
@@ -72,21 +72,21 @@ public class VertxUtilsTest {
       SessionStore<VertxWebContext> sessionStore = new DummySessionStore(vertx, null);
 
       VertxWebContext ctx = VertxUtils.createWebContext(rc);
-      assertNull(sessionStore.get(ctx, KEY));
+      assertNull(sessionStore.get(ctx, KEY).orElse(null));
       assertEquals("", sessionStore.getOrCreateSessionId(ctx));
-      
-      sessionStore = sessionStore.buildFromTrackableSession(ctx, session);
-      assertEquals(VALUE, sessionStore.get(ctx, KEY));
+
+      sessionStore = sessionStore.buildFromTrackableSession(ctx, session).get();
+      assertEquals(VALUE, sessionStore.get(ctx, KEY).get());
 
       sessionStore.set(ctx, KEY, VALUE2);
-      assertEquals(VALUE2, sessionStore.get(ctx, KEY));
+      assertEquals(VALUE2, sessionStore.get(ctx, KEY).get());
 
       assertNotNull(sessionStore.getOrCreateSessionId(ctx));
 
       assertTrue(sessionStore.renewSession(ctx));
 
       assertTrue(sessionStore.destroySession(ctx));
-      assertNull(sessionStore.getTrackableSession(ctx));
+      assertNull(sessionStore.getTrackableSession(ctx).orElse(null));
 
       rc.response()
         .setStatusCode(200)


### PR DESCRIPTION
pac4j-saml 3.8.3 depends on cryptacular 1.2.3 that has this
denial of service security vulnerability:
* CiphertextHeader.java in Cryptacular 1.2.3 allows attackers to trigger
  excessive memory allocation during a decode operation, because the nonce
  array length associated with "new byte" may depend on untrusted input
  within the header of encoded data.
  https://nvd.nist.gov/vuln/detail/CVE-2020-7226

Upgrading to pac4j-saml-opensamlv3:jar:4.1.0 will use the fixed version
cryptacular 1.2.4.

Also bump the other dependencies:
RMB from 30.2.6 to 30.2.9.
Vert.x from to 3.9.2 to 3.9.4.
pac4j from 3.8.3 to 4.1.0.
vertx-pac4j from 4.1.1 to 5.0.0.
JUnit from 4.12 to 4.13.1 to fix another security vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2020-15250

A few code changes are needed, see pac4j 4.0 release notes:
http://www.pac4j.org/docs/index.html#the-pac4j-engine-core-documentationv4-0