### PR TITLE
Make UrlUtilTest locale independent 

### DIFF
--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -28,7 +28,7 @@ public class UrlUtil {
     .map(httpResponse -> {
       String contentType = httpResponse.getHeader("Content-Type");
       if (! contentType.contains("xml")) {
-        throw new IllegalArgumentException("Response content-type is not XML");
+        return UrlCheckResult.failResult("Response content-type is not XML");
       }
       return UrlCheckResult.emptySuccessResult();
     })

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -1,11 +1,10 @@
 package org.folio.util;
 
+import java.net.ConnectException;
 import java.net.URI;
 
 import org.folio.util.model.UrlCheckResult;
-
 import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 
@@ -23,27 +22,23 @@ public class UrlUtil {
   }
 
   public static Future<UrlCheckResult> checkIdpUrl(String url, Vertx vertx) {
-    Promise<UrlCheckResult> promise = Promise.promise();
-
     WebClient client = WebClientFactory.getWebClient(vertx);
 
-    client.getAbs(url).send(ar -> {
-      try {
-        if (ar.failed()) {
-          promise.complete(UrlCheckResult.failResult(ar.cause().getMessage()));
-          return;
-        }
-        String contentType = ar.result().getHeader("Content-Type");
-        if (contentType.contains("xml")) {
-          promise.complete(UrlCheckResult.emptySuccessResult());
-          return;
-        }
-        promise.complete(UrlCheckResult.failResult("Response content-type is not XML"));
-      } catch (Exception e) {
-        promise.complete(UrlCheckResult.failResult("Unexpected error: " + e.getMessage()));
+    return client.getAbs(url).send()
+    .map(httpResponse -> {
+      String contentType = httpResponse.getHeader("Content-Type");
+      if (! contentType.contains("xml")) {
+        throw new IllegalArgumentException("Response content-type is not XML");
       }
+      return UrlCheckResult.emptySuccessResult();
+    })
+    .otherwise(cause -> {
+      if (cause instanceof ConnectException) {
+        // add locale independent prefix, Netty puts a locale dependent translation into getMessage(),
+        // for example German "Verbindungsaufbau abgelehnt:" for English "Connection refused:"
+        return UrlCheckResult.failResult("ConnectException: " + cause.getMessage());
+      }
+      return UrlCheckResult.failResult("Unexpected error: " + cause.getMessage());
     });
-
-    return promise.future();
   }
 }

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -79,7 +79,7 @@ public class UrlUtilTest {
   public void checkIdpUrlJson(TestContext context) {
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/json", vertx)
       .onComplete(context.asyncAssertSuccess(result -> {
-        context.assertEquals("Unexpected error: Response content-type is not XML", result.getMessage());
+        context.assertEquals("Response content-type is not XML", result.getMessage());
       }));
   }
 }

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -1,5 +1,8 @@
 package org.folio.util;
 
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.tools.utils.NetworkUtils;
@@ -59,7 +62,8 @@ public class UrlUtilTest {
     int port = NetworkUtils.nextFreePort();
     UrlUtil.checkIdpUrl("http://localhost:" + port, vertx)
       .onComplete(context.asyncAssertSuccess(result -> {
-          context.assertEquals("Connection refused: localhost/127.0.0.1:" + port, result.getMessage());
+          // check locale independent prefix only.
+          assertThat(result.getMessage(), startsWith("ConnectException: "));
       }));
   }
 
@@ -75,7 +79,7 @@ public class UrlUtilTest {
   public void checkIdpUrlJson(TestContext context) {
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/json", vertx)
       .onComplete(context.asyncAssertSuccess(result -> {
-        context.assertEquals("Response content-type is not XML", result.getMessage());
+        context.assertEquals("Unexpected error: Response content-type is not XML", result.getMessage());
       }));
   }
 }


### PR DESCRIPTION
Running UrlUtilTest with German locale fails:

java.lang.AssertionError: Not equals : Connection refused: localhost/127.0.0.1:51477 != Verbindungsaufbau abgelehnt: localhost/127.0.0.1:51477
        at org.folio.util.UrlUtilTest.lambda$checkIdpUrlNon200$1(UrlUtilTest.java:62)

Change UrlUtil and UrlUtilTest for locale independence.
Futurise UrlUtil.checkIdpUrl.