### PR TITLE
MODLOGSAML-63 Implement CSRF Prevention

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,6 +12,7 @@
           ],
           "pathPattern": "/saml/login",
           "permissionsRequired": [],
+          "delegateCORS": true,
           "modulePermissions": [
             "configuration.entries.collection.get"
           ]
@@ -22,6 +23,7 @@
           ],
           "pathPattern": "/saml/callback",
           "permissionsRequired": [],
+          "delegateCORS": true,
           "modulePermissions": [
             "auth.signtoken",
             "configuration.entries.collection.get",

--- a/ramls/saml-login.raml
+++ b/ramls/saml-login.raml
@@ -47,6 +47,16 @@ types:
           body:
             text/plain:
               example: "Internal server error"
+    options:
+      description: "Preflight CORS for /saml/login"
+      responses:
+        204:
+          description: "Return with appropriate CORS headers"
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
   /callback:
     post:
       description: Redirect browser to sso-landing page with generated token.
@@ -79,6 +89,16 @@ types:
           body:
             text/plain:
               example: "Internal server error"
+    options:
+      description: "Preflight CORS for /saml/callback"
+      responses:
+        204:
+          description: "Return with appropriate CORS headers"
+        400:
+          description: "Bad request"
+          body:
+            text/plain:
+              example: "Bad request"
   /check:
     get:
       description: Decides if SSO login is configured properly, returns true or false

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -278,7 +278,7 @@ public class SamlAPITest {
       .options("/saml/login")
       .then()
       .statusCode(400)
-      .statusLine(containsString("Missing origin header"));
+      .statusLine(containsString("Missing/Invalid origin header"));
 
     log.info("=== Test CORS preflight - OPTIONS /saml/login - failure - invalid origin ===");
     given()


### PR DESCRIPTION
Please https://issues.folio.org/browse/MODLOGSAML-63. The basic idea is to generate a random id and store in the cookie. Later then compare the value during /callback call. There is a detailed explanation in @craigmcnally's original [PR](https://github.com/folio-org/mod-login-saml/pull/63). I simplified the implementation. Hopefully it did not lower the security requirement.