### PR TITLE
MODLOGSAML-58 Arbitrary URL Redirection in SAML Response

### DIFF
--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -174,7 +174,7 @@ public class SamlAPI implements Saml {
     final URI stripesBaseUrl = UrlUtil.parseBaseUrl(originalUrl);
 
     Cookie relayStateCookie = routingContext.getCookie(RELAY_STATE);
-    if(relayStateCookie == null || !relayState.contentEquals(relayStateCookie.getValue())) {
+    if (relayStateCookie == null || !relayState.contentEquals(relayStateCookie.getValue())) {
       asyncResultHandler.handle(Future.succeededFuture(PostSamlCallbackResponse.respond403WithTextPlain("CSRF attempt detected")));
       return;
     }
@@ -250,7 +250,7 @@ public class SamlAPI implements Saml {
                               asyncResultHandler.handle(Future.succeededFuture(PostSamlCallbackResponse.respond500WithTextPlain(tokenResponse.getError().toString())));
                             } else {
                               String candidateAuthToken = null;
-                              if(tokenResponse.getCode() == 200) {
+                              if (tokenResponse.getCode() == 200) {
                                 candidateAuthToken = tokenResponse.getHeaders().get(OkapiHeaders.OKAPI_TOKEN_HEADER);
                               } else { //mod-authtoken v2.x returns 201, with token in JSON response body
                                 try {

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -69,7 +69,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.Cookie;
-import io.vertx.core.http.CookieSameSite;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -90,6 +89,7 @@ public class SamlAPI implements Saml {
   private static final Logger log = LogManager.getLogger(SamlAPI.class);
   public static final String QUOTATION_MARK_CHARACTER = "\"";
   public static final String CSRF_TOKEN = "csrfToken";
+  public static final String RELAY_STATE = "relayState";
 
   /**
    * Check that client can be loaded, SAML-Login button can be displayed.
@@ -114,16 +114,16 @@ public class SamlAPI implements Saml {
                             Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     String csrfToken = UUID.randomUUID().toString();
-    Cookie csrfCookie = Cookie.cookie(CSRF_TOKEN, csrfToken)
-      .setPath("/").setHttpOnly(true).setSecure(true);
-    routingContext.addCookie(csrfCookie);
-
     String stripesUrl = requestEntity.getStripesUrl();
-    String relayInfo = stripesUrl + (stripesUrl.indexOf('?') >= 0 ? '&' : '?') + CSRF_TOKEN + '=' + csrfToken;
+    String relayState = stripesUrl + (stripesUrl.indexOf('?') >= 0 ? '&' : '?') + CSRF_TOKEN + '=' + csrfToken;
+    Cookie relayStateCookie = Cookie.cookie(RELAY_STATE, relayState)
+        .setPath("/").setHttpOnly(true).setSecure(true);
+    routingContext.addCookie(relayStateCookie);
+
 
     // register non-persistent session (this request only) to overWrite relayState
     Session session = new SharedDataSessionImpl(new PRNG(vertxContext.owner()));
-    session.put(SAML_RELAY_STATE_ATTRIBUTE, relayInfo);
+    session.put(SAML_RELAY_STATE_ATTRIBUTE, relayState);
     routingContext.setSession(session);
 
     findSaml2Client(routingContext, false, false) // do not allow login, if config is missing
@@ -173,8 +173,8 @@ public class SamlAPI implements Saml {
     final URI originalUrl = relayStateUrl;
     final URI stripesBaseUrl = UrlUtil.parseBaseUrl(originalUrl);
 
-    Cookie csrfTokenCookie = routingContext.getCookie(CSRF_TOKEN);
-    if(csrfTokenCookie == null || !originalUrl.getQuery().contains(CSRF_TOKEN + "=" +csrfTokenCookie.getValue())) {
+    Cookie relayStateCookie = routingContext.getCookie(RELAY_STATE);
+    if(relayStateCookie == null || !relayState.contentEquals(relayStateCookie.getValue())) {
       asyncResultHandler.handle(Future.succeededFuture(PostSamlCallbackResponse.respond403WithTextPlain("CSRF attempt detected")));
       return;
     }

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -431,6 +431,18 @@ public class SamlAPITest {
       .then()
       .statusCode(403);
 
+    log.info("=== Test - POST /saml/callback - failure (wrong relay) ===");
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .cookie(SamlAPI.RELAY_STATE, cookie)
+      .formParam("SAMLResponse", "saml-response")
+      .formParam("RelayState", relayState.replace("localhost", "demo"))
+      .post("/saml/callback")
+      .then()
+      .statusCode(403);
+
     log.info("=== Test - POST /saml/callback - failure (no cookie) ===");
     given()
       .header(TENANT_HEADER)

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -193,9 +193,9 @@ public class SamlAPITest {
       .statusCode(200)
       .extract();
 
-    String csrfToken = resp.cookie("csrfToken");
-    String relayState = resp.body().jsonPath().getString("relayState");
-    assertEquals(STRIPES_URL+"?csrfToken="+csrfToken, relayState);
+    String cookie = resp.cookie(SamlAPI.RELAY_STATE);
+    String relayState = resp.body().jsonPath().getString(SamlAPI.RELAY_STATE);
+    assertEquals(cookie, relayState);
 
     // stripesUrl w/ query args
     resp = given()
@@ -212,9 +212,9 @@ public class SamlAPITest {
       .statusCode(200)
       .extract();
 
-    csrfToken = resp.cookie("csrfToken");
+    cookie = resp.cookie(SamlAPI.RELAY_STATE);
     relayState = resp.body().jsonPath().getString("relayState");
-    assertEquals(STRIPES_URL+"?foo=bar&csrfToken="+csrfToken, relayState);
+    assertEquals(cookie, relayState);
 
     // AJAX 401
     given()
@@ -386,7 +386,7 @@ public class SamlAPITest {
   public void callbackEndpointTests() throws IOException {
     final String testPath = "/test/path";
 
-    log.info("=== Setup - POST /saml/login - need relayState and csrfToken cookie ===");
+    log.info("=== Setup - POST /saml/login - need relayState and cookie ===");
     ExtractableResponse<Response> resp = given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
@@ -401,17 +401,15 @@ public class SamlAPITest {
       .statusCode(200)
       .extract();
 
-    String csrfToken = resp.cookie("csrfToken");
-    String relayState = resp.body()
-      .jsonPath()
-      .getString("relayState");
+    String cookie = resp.cookie(SamlAPI.RELAY_STATE);
+    String relayState = resp.body().jsonPath().getString(SamlAPI.RELAY_STATE);
 
     log.info("=== Test - POST /saml/callback - success ===");
     given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
       .header(OKAPI_URL_HEADER)
-      .cookie("csrfToken", csrfToken)
+      .cookie(SamlAPI.RELAY_STATE, cookie)
       .formParam("SAMLResponse", "saml-response")
       .formParam("RelayState", relayState)
       .post("/saml/callback")
@@ -421,7 +419,19 @@ public class SamlAPITest {
       .header("x-okapi-token", "saml-token")
       .cookie("ssoToken", "saml-token");
 
-    log.info("=== Test - POST /saml/callback - failure (no CSRF token cookie) ===");
+    log.info("=== Test - POST /saml/callback - failure (wrong cookie) ===");
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(OKAPI_URL_HEADER)
+      .cookie(SamlAPI.RELAY_STATE, "bad" + cookie)
+      .formParam("SAMLResponse", "saml-response")
+      .formParam("RelayState", relayState)
+      .post("/saml/callback")
+      .then()
+      .statusCode(403);
+
+    log.info("=== Test - POST /saml/callback - failure (no cookie) ===");
     given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)


### PR DESCRIPTION
Please see https://issues.folio.org/browse/MODLOGSAML-58. This PR basically leveraged the same cookie approach used for CSRF detection. Expanded the cookie value to include the relay url as well. By doing so the SAML response redirection url will have to match the original requester one.