### PR TITLE
MODLOGSAML-102: Remove xerces:xmlParserAPIs and xml-apis dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- remove xerces exclusion when upgrading to RMB >= 33.0.3: https://issues.folio.org/browse/RMB-859 -->
     <raml-module-builder-version>33.0.2</raml-module-builder-version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xerces</groupId>
+          <artifactId>xmlParserAPIs</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -89,6 +95,12 @@
       <groupId>org.pac4j</groupId>
       <artifactId>pac4j-saml-opensamlv3</artifactId>
       <version>${pac4j.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
mod-login-saml has these dependencies:

* xerces:xmlParserAPIs:2.6.2 via domain-models-runtime
* xml-apis: xml-apis:1.3.04 via pac4j-saml-opensamlv3

Both libraries haven been included into JDK since Java 9.

Using any of these classes (org.w3c.dom.**) causes this
compile error in Java compilers that comply with the Java specs
(for example the one used by Eclipse):

`The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml`

Solution:

Exclude these dependencies.