### PR TITLE
MODLOGSAML-130: Pac4j 5.2.1, RMB 33.2.4, vertx-pac4j 6.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <raml-module-builder-version>33.2.3</raml-module-builder-version>
+    <raml-module-builder-version>33.2.4</raml-module-builder-version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <pac4j.version>5.1.4</pac4j.version>
+    <pac4j.version>5.2.1</pac4j.version>
     <rest-assured.version>4.4.0</rest-assured.version>
-    <vertx-pac4j.version>6.0.0-FOLIO.1</vertx-pac4j.version>
+    <vertx-pac4j.version>6.0.0</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
 


### PR DESCRIPTION
Pac4j v5.1 and earlier allows (by default) clients to accept and successfully validate ID Tokens with "none" algorithm. This is insecure because it disables signature validation:

* https://nvd.nist.gov/vuln/detail/CVE-2021-44878

Update Pac4j from 5.1.4 to 5.2.1.

Also update RMB 33.2.3 to 33.2.4.

And update vertx-pac4j from 6.0.0-FOLIO.1 to 6.0.0.