### PR TITLE
MODLOGSAML-107: slf4j, web client timeout 15s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <raml-module-builder-version>33.2.5</raml-module-builder-version>
+    <raml-module-builder-version>33.2.7</raml-module-builder-version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
@@ -51,13 +51,23 @@
 
   <dependencyManagement>
     <dependencies>
+
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.4</version>
+        <version>4.2.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+     </dependency>
+
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
@@ -74,6 +84,11 @@
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
       <version>${raml-module-builder-version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 
     <dependency>
@@ -103,13 +118,6 @@
           <artifactId>xml-apis</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- Remove as soon as pac4j-core requires spring-core >= 5.3.15 -->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>5.3.15</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -7,13 +7,11 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.config.model.SamlConfiguration;
 import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.okapi.common.WebClientFactory;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.util.PercentCodec;
-import org.folio.util.WebClientFactory;
 import org.folio.util.model.OkapiHeaders;
 import org.springframework.util.Assert;
 
@@ -28,8 +26,6 @@ import java.util.stream.Collectors;
  * @author rsass
  */
 public class ConfigurationsClient {
-
-  private static final Logger log = LogManager.getLogger(ConfigurationsClient.class);
 
   public static final String CONFIGURATIONS_ENTRIES_ENDPOINT_URL = "/configurations/entries";
   public static final String MODULE_NAME = "LOGIN-SAML";

--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -2,6 +2,7 @@ package org.folio.config;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.SamlLogin;
@@ -41,6 +42,13 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
     this.client = client;
   }
 
+  private String dump(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return ToStringBuilder.reflectionToString(o);
+  }
+
   @Override
   public Optional<RedirectionAction> getRedirectionAction(WebContext webContext, SessionStore sessionStore) {
 
@@ -75,6 +83,10 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
 
       return Optional.of(new OkAction(Json.encode(samlLogin)));
     } catch (Exception e) {
+      log.error(() -> "getRedirectionAction saml2ObjectBuilder: " + dump(new SAML2AuthnRequestBuilder()));
+      log.error(() -> "getRedirectionAction client: " + dump(client));
+      log.error(() -> "getRedirectionAction webContext: " + dump(webContext));
+      log.error(() -> "getRedirectionAction sessionStore: " + dump(sessionStore));
       log.error("Exception processing SAML login request: {}", e.getMessage(), e);
       throw new StatusAction(500);
     }

--- a/src/main/java/org/folio/rest/impl/ApiInitializer.java
+++ b/src/main/java/org/folio/rest/impl/ApiInitializer.java
@@ -4,7 +4,6 @@ import io.vertx.core.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.resource.interfaces.InitAPI;
-import org.folio.util.WebClientFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -19,8 +18,6 @@ public class ApiInitializer implements InitAPI {
 
   @Override
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
-    WebClientFactory.init(vertx);
-
     String tacEnv = System.getenv("TRUST_ALL_CERTIFICATES");
 
     if ("true".equals(tacEnv)) {

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -2,7 +2,6 @@ package org.folio.util;
 
 import java.net.ConnectException;
 import java.net.URI;
-
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;

--- a/src/main/java/org/folio/util/WebClientFactory.java
+++ b/src/main/java/org/folio/util/WebClientFactory.java
@@ -1,39 +1,26 @@
 package org.folio.util;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 
 public class WebClientFactory {
 
-  public static final int DEFAULT_TIMEOUT = 5000;
-  public static final boolean DEFAULT_KEEPALIVE = false;
-
-  private static final Map<Vertx, WebClient> clients = new HashMap<>();
-
-  public static WebClient getWebClient(Vertx vertx) {
-    return clients.get(vertx);
-  }
+  private static final WebClientOptions options = webClientOptions();
+  /** reduce from 60 seconds to 15 seconds */
+  public static final int DEFAULT_TIMEOUT = 15000;
 
   private WebClientFactory() {
   }
 
-  /**
-   * Initializes a WebClient for the provided Vertx.
-   * Calling this method more than once with the same Vertx has no effect.
-   *
-   * @param vertx Vert.x
-   */
-  public static synchronized void init(Vertx vertx) {
-    if (vertx != null && !clients.containsKey(vertx)) {
-      WebClientOptions options = new WebClientOptions();
-      options.setKeepAlive(DEFAULT_KEEPALIVE);
-      options.setConnectTimeout(DEFAULT_TIMEOUT);
-      options.setIdleTimeout(DEFAULT_TIMEOUT);
-      clients.put(vertx, WebClient.create(vertx, options));
-    }
+  private static WebClientOptions webClientOptions() {
+    var webClientOptions = new WebClientOptions();
+    webClientOptions.setConnectTimeout(DEFAULT_TIMEOUT);
+    webClientOptions.setIdleTimeout(DEFAULT_TIMEOUT);
+    return webClientOptions;
+  }
+
+  public static WebClient getWebClient(Vertx vertx) {
+    return org.folio.okapi.common.WebClientFactory.getWebClient(vertx, options);
   }
 }

--- a/src/test/java/org/folio/rest/impl/IdpTest.java
+++ b/src/test/java/org/folio/rest/impl/IdpTest.java
@@ -116,6 +116,12 @@ public class IdpTest {
     setIdpBinding("POST");
     setOkapi("mock_idptest_post.json");
 
+    for (int i = 0; i < 2; i++) {
+      post0();
+    }
+  }
+
+  private void post0() {
     ExtractableResponse<Response> resp = given()
       .header(TENANT_HEADER)
       .header(TOKEN_HEADER)
@@ -140,7 +146,6 @@ public class IdpTest {
         formParams("SAMLRequest", samlRequest).
         post(location).
         then().
-        log().all().
         statusCode(200).
         body(containsString("<form method=\"post\" "),
               containsString("action=\"" + OKAPI_URL + "/_/invoke/tenant/diku/saml/callback\">")).
@@ -157,7 +162,6 @@ public class IdpTest {
       formParams("SAMLResponse", matcher.group(1)).
       post(MODULE_URL + "/saml/callback").
     then().
-      log().all().
       statusCode(302).
       header("x-okapi-token", "saml-token").
       header("Location", startsWith("http://localhost:3000/sso-landing?ssoToken=saml-token"));
@@ -167,6 +171,13 @@ public class IdpTest {
   public void redirect() {
     setIdpBinding("Redirect");
     setOkapi("mock_idptest_redirect.json");
+
+    for (int i = 0; i < 2; i++) {
+      redirect0();
+    }
+  }
+
+  private void redirect0() {
     ExtractableResponse<Response> resp =
         given().
           header(TENANT_HEADER).
@@ -180,7 +191,6 @@ public class IdpTest {
           statusCode(200).
           body("bindingMethod", is("GET")).
           body("location", containsString("/simplesaml/saml2/idp/SSOService.php?")).
-          log().all().
           extract();
 
     Cookie cookie = resp.detailedCookie(SamlAPI.RELAY_STATE);
@@ -203,7 +213,6 @@ public class IdpTest {
         when().
           get(location).
         then().
-          log().all().
           statusCode(200).
           body(containsString(" method=\"post\" "),
                containsString("action=\"" + OKAPI_URL + "/_/invoke/tenant/diku/saml/callback\">")).
@@ -221,7 +230,6 @@ public class IdpTest {
     when().
       post(MODULE_URL + "/saml/callback").
     then().
-      log().all().
       statusCode(302).
       header("x-okapi-token", "saml-token").
       header("Location", startsWith("http://localhost:3000/sso-landing?ssoToken=saml-token"));

--- a/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -1,0 +1,7 @@
+package org.folio.rest.tools.utils;
+
+public class ModuleName {
+  public static String getModuleName() {
+    return "mod-login-saml";
+  }
+}

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -3,8 +3,6 @@ package org.folio.util;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -20,8 +18,6 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class UrlUtilTest {
-
-  private static final Logger log = LogManager.getLogger(UrlUtilTest.class);
 
   public static final int MOCK_PORT = NetworkUtils.nextFreePort();
 
@@ -41,7 +37,6 @@ public class UrlUtilTest {
   @Before
   public void before(TestContext context) {
     vertx = Vertx.vertx();
-    WebClientFactory.init(vertx);
   }
 
   @AfterClass


### PR DESCRIPTION
Update RMB from 33.2.5 to 33.2.7.
Update Vert.x from 4.2.4 to 4.2.5.
Add log4j-slf4j-impl to also get slf4j log messages (via log4j).

Dump variables when getRedirectionAction has an exception.

Use WebClientFactory from okapi-common.

For web client increase connect timeout and idle timeout
from 5 seconds to 15 seconds, and enable keep alive.