### PR TITLE
MODLOGSAML-107: Delete configuration cache on internal error

### DIFF
--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -95,10 +95,6 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
     try {
       log.error(() -> "  webContext: " + dump(webContext));
       log.error(() -> "  client: " + dump(client));
-      var conf = client.getConfiguration();
-      log.error(() -> "  IdP metadata resource: " + dump(conf.getIdentityProviderMetadataResource()));
-      log.error(() -> "  IdP metadata resolver: " + dump(conf.getIdentityProviderMetadataResolver()));
-      log.error(() -> "  IdP metadata: " + conf.getIdentityProviderMetadataResolver().getMetadata());
     } catch (Exception e) {
       // ignore
     }

--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -2,10 +2,10 @@ package org.folio.config;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.SamlLogin;
+import org.folio.util.DumpUtil;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -20,7 +20,6 @@ import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.sso.impl.SAML2AuthnRequestBuilder;
 import org.pac4j.saml.transport.Pac4jSAMLResponse;
-import org.springframework.core.io.ByteArrayResource;
 import io.vertx.core.json.Json;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.xml.SerializeSupport;
@@ -40,20 +39,6 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
   public JsonReponseSaml2RedirectActionBuilder(final SAML2Client client) {
     CommonHelper.assertNotNull("client", client);
     this.client = client;
-  }
-
-  private String dump(Object o) {
-    try {
-      if (o == null) {
-        return "null";
-      }
-      if (o instanceof ByteArrayResource) {  // IdP metadata XML
-        return new String(((ByteArrayResource) o).getByteArray(), StandardCharsets.UTF_8);
-      }
-      return ToStringBuilder.reflectionToString(o);
-    } catch (Exception e) {
-      return e.getClass().getName() + " " + e.getMessage();
-    }
   }
 
   @Override
@@ -93,8 +78,8 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
     }
 
     try {
-      log.error(() -> "  webContext: " + dump(webContext));
-      log.error(() -> "  client: " + dump(client));
+      log.error(() -> "  webContext: " + DumpUtil.dump(webContext));
+      log.error(() -> "  client: " + DumpUtil.dump(client));
     } catch (Exception e) {
       // ignore
     }

--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -75,16 +75,10 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
       return Optional.of(new OkAction(Json.encode(samlLogin)));
     } catch (Exception e) {
       log.error("Exception processing SAML login request: {}", e.getMessage(), e);
-    }
-
-    try {
       log.error(() -> "  webContext: " + DumpUtil.dump(webContext));
       log.error(() -> "  client: " + DumpUtil.dump(client));
-    } catch (Exception e) {
-      // ignore
+      throw new StatusAction(500);
     }
-
-    throw new StatusAction(500);
   }
 
 }

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -41,7 +41,6 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.sstore.impl.SharedDataSessionImpl;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.config.ConfigurationsClient;
@@ -62,6 +61,7 @@ import org.folio.rest.jaxrs.resource.Saml;
 import org.folio.session.NoopSession;
 import org.folio.util.Base64Util;
 import org.folio.util.ConfigEntryUtil;
+import org.folio.util.DumpUtil;
 import org.folio.util.DummySessionStore;
 import org.folio.util.HttpActionMapper;
 import org.folio.util.OkapiHelper;
@@ -466,19 +466,12 @@ public class SamlAPI implements Saml {
       .onSuccess(result -> configHolder.putClient(tenantId, result));
   }
 
-  static String dump(Object o) {
-    if (o == null) {
-      return "null";
-    }
-    return ToStringBuilder.reflectionToString(o);
-  }
-
   private void removeSaml2Client(RoutingContext routingContext) {
     String tenantId = OkapiHelper.okapiHeaders(routingContext).getTenant();
     try {
       SAML2Configuration conf = SamlConfigHolder.getInstance().findClient(tenantId).getClient().getConfiguration();
-      log.error(() -> "IdP metadata resolver: " + dump(conf.getIdentityProviderMetadataResolver()));
-      log.error(() -> "IdP metadata resource: " + dump(conf.getIdentityProviderMetadataResource()));
+      log.error(() -> "IdP metadata resolver: " + DumpUtil.dump(conf.getIdentityProviderMetadataResolver()));
+      log.error(() -> "IdP metadata resource: " + DumpUtil.dump(conf.getIdentityProviderMetadataResource()));
       try (InputStream inputStream = conf.getIdentityProviderMetadataResource().getInputStream()) {
         String metadata = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         log.error(() -> "IdP metadata: " + metadata);

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -10,7 +10,9 @@ import static io.vertx.core.http.HttpHeaders.ORIGIN;
 import static io.vertx.core.http.HttpHeaders.VARY;
 import static org.pac4j.saml.state.SAML2StateGenerator.SAML_RELAY_STATE_ATTRIBUTE;
 
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +40,8 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import io.vertx.ext.web.impl.Utils;
 import io.vertx.ext.web.sstore.impl.SharedDataSessionImpl;
-
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.config.ConfigurationsClient;
@@ -135,10 +138,10 @@ public class SamlAPI implements Saml {
     findSaml2Client(routingContext, false, false, vertxContext) // do not allow login, if config is missing
       .map(SamlClientComposite::getClient)
       .map(saml2client -> postSamlLoginResponse(routingContext, saml2client))
-      .recover(e -> {
+      .otherwise(e -> {
         log.warn(e.getMessage(), e);
         removeSaml2Client(routingContext);
-        return Future.succeededFuture(PostSamlLoginResponse.respond500WithTextPlain("Internal Server Error"));
+        return PostSamlLoginResponse.respond500WithTextPlain("Internal Server Error");
       })
       .onSuccess(response -> asyncResultHandler.handle(Future.succeededFuture(response)));
   }
@@ -419,7 +422,7 @@ public class SamlAPI implements Saml {
   private Future<String> regenerateSaml2Config(RoutingContext routingContext, Context vertxContext) {
 
     return findSaml2Client(routingContext, false, false, vertxContext)
-      .compose(result -> {
+      .<String>compose(result -> {
         Vertx vertx = vertxContext.owner();
         SAML2Client saml2Client = result.getClient();
         return vertx.executeBlocking(blockingCode -> {
@@ -436,8 +439,9 @@ public class SamlAPI implements Saml {
             blockingCode.fail(e);
           }
         });
-      });
-}
+      })
+      .onFailure(e -> removeSaml2Client(routingContext));
+  }
 
   /**
    * @param routingContext        the actual routing context
@@ -462,8 +466,26 @@ public class SamlAPI implements Saml {
       .onSuccess(result -> configHolder.putClient(tenantId, result));
   }
 
+  static String dump(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return ToStringBuilder.reflectionToString(o);
+  }
+
   private void removeSaml2Client(RoutingContext routingContext) {
     String tenantId = OkapiHelper.okapiHeaders(routingContext).getTenant();
+    try {
+      SAML2Configuration conf = SamlConfigHolder.getInstance().findClient(tenantId).getClient().getConfiguration();
+      log.error(() -> "IdP metadata resolver: " + dump(conf.getIdentityProviderMetadataResolver()));
+      log.error(() -> "IdP metadata resource: " + dump(conf.getIdentityProviderMetadataResource()));
+      try (InputStream inputStream = conf.getIdentityProviderMetadataResource().getInputStream()) {
+        String metadata = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+        log.error(() -> "IdP metadata: " + metadata);
+      }
+    } catch (Exception e) {
+      // ignore
+    }
     SamlConfigHolder.getInstance().removeClient(tenantId);
   }
 

--- a/src/main/java/org/folio/util/DumpUtil.java
+++ b/src/main/java/org/folio/util/DumpUtil.java
@@ -1,0 +1,16 @@
+package org.folio.util;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public final class DumpUtil {
+  private DumpUtil() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
+
+  public static String dump(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return ToStringBuilder.reflectionToString(o);
+  }
+}

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -3,9 +3,11 @@ package org.folio.rest.impl;
 import static io.restassured.RestAssured.given;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -20,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.config.SamlConfigHolder;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.SamlConfigRequest;
@@ -835,5 +838,11 @@ public class SamlAPITest {
     assertEquals("Unsupported user property: externalsystemid", assertThrows(RuntimeException.class, () ->
       SamlAPI.getCqlUserQuery("externalsystemid", "user@saml.com"))
       .getMessage());
+  }
+
+  //@Test
+  public void dump() {
+    assertThat(SamlAPI.dump(null), is("null"));
+    assertThat(SamlAPI.dump(new AtomicInteger(9876)), allOf(containsString("AtomicInteger"), containsString("9876")));
   }
 }

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -3,11 +3,9 @@ package org.folio.rest.impl;
 import static io.restassured.RestAssured.given;
 import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
 import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -22,7 +20,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.config.SamlConfigHolder;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.jaxrs.model.SamlConfigRequest;
@@ -838,11 +835,5 @@ public class SamlAPITest {
     assertEquals("Unsupported user property: externalsystemid", assertThrows(RuntimeException.class, () ->
       SamlAPI.getCqlUserQuery("externalsystemid", "user@saml.com"))
       .getMessage());
-  }
-
-  //@Test
-  public void dump() {
-    assertThat(SamlAPI.dump(null), is("null"));
-    assertThat(SamlAPI.dump(new AtomicInteger(9876)), allOf(containsString("AtomicInteger"), containsString("9876")));
   }
 }

--- a/src/test/java/org/folio/util/DumpUtilTest.java
+++ b/src/test/java/org/folio/util/DumpUtilTest.java
@@ -1,0 +1,29 @@
+package org.folio.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.folio.rest.testing.UtilityClassTester;
+import org.junit.Test;
+
+public class DumpUtilTest {
+
+  @Test
+  public void test() {
+    UtilityClassTester.assertUtilityClass(DumpUtil.class);
+  }
+
+  @Test
+  public void dumpNull() {
+    assertThat(DumpUtil.dump(null), is("null"));
+  }
+
+  @Test
+  public void dumpContent() {
+    assertThat(DumpUtil.dump(new AtomicInteger(9876)), allOf(containsString("AtomicInteger"), containsString("9876")));
+  }
+
+}

--- a/src/test/java/org/folio/util/MockJson.java
+++ b/src/test/java/org/folio/util/MockJson.java
@@ -43,6 +43,7 @@ public class MockJson extends AbstractVerticle {
     HttpServerResponse response = context.response();
     String method = request.method().name();
     String uri = request.uri();
+
     for (int i = 0; i < mocks.size(); i++) {
       JsonObject entry = mocks.getJsonObject(i);
       if (method.equalsIgnoreCase(entry.getString("method", "get"))
@@ -55,13 +56,17 @@ public class MockJson extends AbstractVerticle {
             response.putHeader(headObject.getString("name"), headObject.getString("value"));
           }
         }
-        JsonObject responseData = entry.getJsonObject("receivedData");
-        if (responseData != null) {
-          response.putHeader("Content-Type", "application/json");
-          response.end(responseData.encodePrettily());
-        } else {
+        Object responseData = entry.getValue("receivedData");
+        if (responseData == null) {
           response.end();
+          return;
         }
+        if (responseData instanceof JsonObject) {
+          response.putHeader("Content-Type", "application/json");
+          response.end(((JsonObject) responseData).encodePrettily());
+          return;
+        }
+        response.end(responseData.toString());
         return;
       }
     }

--- a/src/test/resources/mock_metadata_bogus.json
+++ b/src/test/resources/mock_metadata_bogus.json
@@ -1,6 +1,12 @@
 {
   "mocks": [
     {
+      "url": "/idpmetadata",
+      "method": "get",
+      "status": 200,
+      "receivedData": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"\"></EntityDescriptor>"
+    },
+    {
       "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
@@ -11,7 +17,7 @@
             "module": "LOGIN-SAML",
             "configName": "saml",
             "code": "idp.url",
-            "value": "https://idp.ssocircle.com"
+            "value": "http://localhost:8888/idpmetadata"
           },
           {
             "id": "022d8342-fa51-44d1-8b2b-27da36e11f07",
@@ -56,19 +62,10 @@
           }
 
         ],
-        "totalRecords": 6
+        "totalRecords": 7
       },
       "receivedPath": "",
       "sendData": {}
-    },
-    {
-      "url": "/users?query=externalSystemId%3D%3D%22saml-user-id%22",
-      "method": "get",
-      "status": 200,
-      "receivedData": {
-        "totalRecords": 0,
-        "users": [ ]
-      }
     }
   ]
 }


### PR DESCRIPTION
Remove the Saml2Client (the configuration) from SamlConfigHolder
(the configuration cache) if there is an internal error that
might be caused by a bogus configuration.

The issue can be reproduced with an IdP metadata XML with
entityID set to an empty string.

To see the actual cause the IdP metadata will be logged on
internal error.