### PR TITLE
MODLOGSAML-136: jackson-databind 2.13.2.2 (CVE-2020-36518)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.5</version>
+        <version>4.2.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -87,6 +87,13 @@
   </dependencyManagement>
 
   <dependencies>
+
+    <!-- Remove when vertx-stack-depchain ships with >= 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.2.2</version>
+    </dependency>
 
     <dependency>
       <groupId>org.folio</groupId>


### PR DESCRIPTION
Fixing stack overflow DoS https://nvd.nist.gov/vuln/detail/CVE-2020-36518