### PR TITLE
MODLOGSAML-138: Reduce error logging

### DIFF
--- a/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
+++ b/src/main/java/org/folio/config/JsonReponseSaml2RedirectActionBuilder.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.SamlLogin;
-import org.folio.util.DumpUtil;
 import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -75,8 +74,6 @@ public class JsonReponseSaml2RedirectActionBuilder implements RedirectionActionB
       return Optional.of(new OkAction(Json.encode(samlLogin)));
     } catch (Exception e) {
       log.error("Exception processing SAML login request: {}", e.getMessage(), e);
-      log.error(() -> "  webContext: " + DumpUtil.dump(webContext));
-      log.error(() -> "  client: " + DumpUtil.dump(client));
       throw new StatusAction(500);
     }
   }

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -484,11 +484,11 @@ public class SamlAPI implements Saml {
     String tenantId = OkapiHelper.okapiHeaders(routingContext).getTenant();
     try {
       SAML2Configuration conf = SamlConfigHolder.getInstance().findClient(tenantId).getClient().getConfiguration();
-      log.error(() -> "IdP metadata resolver: " + DumpUtil.dump(conf.getIdentityProviderMetadataResolver()));
-      log.error(() -> "IdP metadata resource: " + DumpUtil.dump(conf.getIdentityProviderMetadataResource()));
+      log.debug(() -> "IdP metadata resolver: " + DumpUtil.dump(conf.getIdentityProviderMetadataResolver()));
+      log.debug(() -> "IdP metadata resource: " + DumpUtil.dump(conf.getIdentityProviderMetadataResource()));
       try (InputStream inputStream = conf.getIdentityProviderMetadataResource().getInputStream()) {
         String metadata = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-        log.error(() -> "IdP metadata: " + metadata);
+        log.debug(() -> "IdP metadata: " + metadata);
       }
     } catch (Exception e) {
       // ignore


### PR DESCRIPTION
For https://issues.folio.org/browse/MODLOGSAML-107 debug information was added when an exception occurred. This also contains sensitive values like the okapi token.

Task: Reduce logging and don't log okapi token.