### PR TITLE
MODLOGSAML-134: Content-Type validation for Duo's text/xhtml

### DIFF
--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -4,6 +4,8 @@ import java.net.ConnectException;
 import java.net.URI;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 
 /**
@@ -23,13 +25,7 @@ public class UrlUtil {
     WebClient client = WebClientFactory.getWebClient(vertx);
 
     return client.getAbs(url).send()
-      .map(httpResponse -> {
-        String contentType = httpResponse.getHeader("Content-Type");
-        if (contentType == null || ! contentType.contains("xml")) {
-          throw new RuntimeException("Response content-type is not XML");
-        }
-        return (Void) null;
-      })
+      .map(UrlUtil::validateXmlContentType)
       .recover(cause -> {
         if (cause instanceof ConnectException) {
           return Future.failedFuture("ConnectException: " + cause.getMessage());
@@ -37,5 +33,27 @@ public class UrlUtil {
           return Future.failedFuture(cause);
         }
       });
+  }
+
+  static Void validateXmlContentType(HttpResponse<Buffer> httpResponse) {
+    String contentType = httpResponse.getHeader("Content-Type");
+    if (contentType == null) {
+      contentType = "";
+    }
+    // workaround for *.sso.duosecurity.com, https://issues.folio.org/browse/MODLOGSAML-134
+    if ("text/xhtml".equals(contentType) && "Duo/1.0".equals(httpResponse.getHeader("Server"))) {
+      return null;
+    }
+    // https://www.w3.org/International/articles/serving-xhtml/
+    // https://www.w3.org/TR/xhtml-media-types/#media-types
+    // https://www.iana.org/assignments/media-types/media-types.xhtml
+    if (contentType.startsWith("text/xml")
+        || contentType.startsWith("application/xml")
+        || contentType.startsWith("application/xhtml+xml")
+        || contentType.startsWith("application/samlmetadata+xml")) {
+      return null;
+    }
+    throw new RuntimeException("Content-Type response header media type must be one of "
+        + "text/xml, application/xml, application/xhtml+xml, application/samlmetadata+xml");
   }
 }

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -6,6 +6,7 @@ import static org.folio.util.Base64AwareXsdMatcher.matchesBase64XsdInClasspath;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
@@ -816,7 +817,7 @@ public class SamlAPITest {
       .statusCode(200)
       .contentType(ContentType.JSON)
       .body("valid", is(false))
-      .body("error", is("Response content-type is not XML"))
+      .body("error", startsWith("Content-Type response header media type must be"))
       .body(matchesJsonSchemaInClasspath("ramls/schemas/SamlValidateResponse.json"));
   }
 

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -1,7 +1,11 @@
 package org.folio.util;
 
-import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
@@ -12,9 +16,11 @@ import org.junit.runner.RunWith;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.client.HttpResponse;
 
 @RunWith(VertxUnitRunner.class)
 public class UrlUtilTest {
@@ -64,7 +70,7 @@ public class UrlUtilTest {
   public void checkIdpUrlNoContentType(TestContext context) {
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/", vertx)
       .onComplete(context.asyncAssertFailure(cause ->
-        context.assertEquals("Response content-type is not XML", cause.getMessage())
+        assertThat(cause.getMessage(), startsWith("Content-Type response header media type must be"))
       ));
   }
 
@@ -72,7 +78,41 @@ public class UrlUtilTest {
   public void checkIdpUrlJson(TestContext context) {
     UrlUtil.checkIdpUrl("http://localhost:" + MOCK_PORT + "/json", vertx)
       .onComplete(context.asyncAssertFailure(cause ->
-        context.assertEquals("Response content-type is not XML", cause.getMessage())
+        assertThat(cause.getMessage(), startsWith("Content-Type response header media type must be"))
       ));
+  }
+
+  @Test
+  public void contentTypeDuo() {
+    @SuppressWarnings("unchecked")
+    HttpResponse<Buffer> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.getHeader("Content-Type")).thenReturn("text/xhtml");
+    when(httpResponse.getHeader("Server")).thenReturn("Duo/1.0");
+    assertThat(UrlUtil.validateXmlContentType(httpResponse), is(nullValue()));
+  }
+
+  void assertContentType(String contentType) {
+    @SuppressWarnings("unchecked")
+    HttpResponse<Buffer> httpResponse = mock(HttpResponse.class);
+    when(httpResponse.getHeader("Content-Type")).thenReturn(contentType);
+    assertThat(UrlUtil.validateXmlContentType(httpResponse), is(nullValue()));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void contentTypeXhtmlNonDuo() {
+    assertContentType("text/xhtml");
+  }
+
+  @Test
+  public void validContentTypes() {
+    assertContentType("text/xml; charset=UTF-8");
+    assertContentType("application/xml; charset=UTF-8");
+    assertContentType("application/xhtml+xml; charset=UTF-8");
+    assertContentType("application/samlmetadata+xml; charset=UTF-8");
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void invalidContentType() {
+    assertContentType("foo/text/xml; charset=UTF-8");
   }
 }


### PR DESCRIPTION
If `Server: Duo/1.0` header exists allow text/xhtml.
Otherwise require one of the four XML media types.