### PR TITLE
MODLOGSAML-142: Upgrade dependencies: RMB 34, Vert.x 4.3.1, pac4j 5.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <raml-module-builder-version>33.2.7</raml-module-builder-version>
+    <raml-module-builder-version>34.0.0</raml-module-builder-version>
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <pac4j.version>5.3.1</pac4j.version>
-    <rest-assured.version>4.4.0</rest-assured.version>
+    <pac4j.version>5.4.3</pac4j.version>
     <vertx-pac4j.version>6.0.1</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -53,9 +52,17 @@
     <dependencies>
 
       <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured-bom</artifactId>
+        <version>5.1.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.6</version>
+        <version>4.3.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -68,18 +75,10 @@
         <scope>import</scope>
       </dependency>
 
-      <dependency>  <!-- remove when pac4j-saml ships with >= 5.3.18. CVE-2022-22965 -->
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-framework-bom</artifactId>
-        <version>5.3.18</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.16.3</version>
+        <version>1.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -88,22 +87,6 @@
 
   <dependencies>
 
-    <!-- Remove when vertx-stack-depchain ships with >= 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.13.2.2</version>
-    </dependency>
-
-    <!-- Remove when pac4j ships with xmlsec >= 2.1.7 or >= 2.2.3 or >= 2.3.0
-         https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-40690
-    -->
-    <dependency>
-      <groupId>org.apache.santuario</groupId>
-      <artifactId>xmlsec</artifactId>
-      <version>2.1.7</version>
-    </dependency>
-    
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
@@ -147,14 +130,12 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -172,9 +153,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.folio.okapi</groupId>
+      <artifactId>okapi-testing</artifactId>
+      <version>4.14.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/org/folio/config/model/SAML2ClientMock.java
+++ b/src/main/java/org/folio/config/model/SAML2ClientMock.java
@@ -17,6 +17,7 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.credentials.SAML2Credentials;
+import org.pac4j.saml.profile.converter.SimpleSAML2AttributeConverter;
 
 public class SAML2ClientMock extends SAML2Client {
 
@@ -32,11 +33,10 @@ public class SAML2ClientMock extends SAML2Client {
   protected Optional<Credentials> retrieveCredentials(WebContext context, SessionStore sessionStore) {
     log.info("Mocking SAML2Client retrieveCredentials...");
 
-    assert(context.getRequestParameter("SAMLResponse").isPresent());
-
     SAML2Credentials.SAMLNameID nameId = SAML2Credentials.SAMLNameID.from(new NameIDBuilder().buildObject());
     String issuerId = this.getClass().getName();
-    List<SAML2Credentials.SAMLAttribute> samlAttributes = SAML2Credentials.SAMLAttribute.from(Collections.emptyList());
+    List<SAML2Credentials.SAMLAttribute> samlAttributes = SAML2Credentials.SAMLAttribute.from(
+        new SimpleSAML2AttributeConverter(), Collections.emptyList());
     Conditions conditions = new ConditionsBuilder().buildObject();
     List<String> authnContexts = new ArrayList<>();
 

--- a/src/test/java/org/folio/util/DumpUtilTest.java
+++ b/src/test/java/org/folio/util/DumpUtilTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import org.folio.rest.testing.UtilityClassTester;
+import org.folio.okapi.testing.UtilityClassTester;
 import org.junit.Test;
 
 public class DumpUtilTest {


### PR DESCRIPTION
Upgrade RMB from 33.2.7 to 34.0.0.
Upgrade Vertx from 4.2.6 to 4.3.1.
Upgrade pac4j from 5.3.1 to 5.4.3.
Remove pinned versions of indirect dependencies - the direct dependenies
come with indirecty versions that contain the security fixes.
Upgrade test dependencies.

Small code changes are required by the new dependency versions.