### PR TITLE
MODLOGSAML-144: spring framework 5.3.21 fixing DoS (CVE-2022-22970)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <generate_routing_context>/saml/callback,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
-    <pac4j.version>5.4.3</pac4j.version>
+    <pac4j.version>5.4.3</pac4j.version>  <!-- remove spring-framework-bom after upgrade to pac4j >= 5.4.4 -->
     <vertx-pac4j.version>6.0.1</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -75,6 +75,21 @@
         <scope>import</scope>
       </dependency>
 
+      <!--
+        Remove after upgrading pac4j >= 5.4.4.
+        https://www.cve.org/CVERecord?id=CVE-2022-22970
+        Applications that handle file uploads are vulnerable to DoS attack
+        if they rely on data binding to set a MultipartFile or
+        javax.servlet.Part to a field in a model object.
+      -->
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>5.3.21</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
@@ -82,6 +97,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-22970

In spring framework versions prior to 5.3.20+ , 5.2.22+ and old unsupported versions, applications that handle file uploads are vulnerable to DoS attack if they rely on data binding to set a MultipartFile or javax.servlet.Part to a field in a model object.

org.pac4j:pac4j-saml@5.4.3 comes with the depenceny org.springframework:spring-beans@5.3.19 and there is no released pac4j-saml version with a fix.

Therefore we need to bump the springframework version. Run

```
mvn dependency:tree -Dincludes=org.springframework
```

to check that the upgrade has correctly been applied:

```
[INFO] org.folio:mod-login-saml:jar:2.5.0-SNAPSHOT
[INFO] \- org.pac4j:pac4j-saml:jar:5.4.3:compile
[INFO]    +- org.springframework:spring-beans:jar:5.3.21:compile
[INFO]    +- org.springframework:spring-orm:jar:5.3.21:compile
[INFO]    |  +- org.springframework:spring-jdbc:jar:5.3.21:compile
[INFO]    |  \- org.springframework:spring-tx:jar:5.3.21:compile
[INFO]    \- org.springframework:spring-core:jar:5.3.21:compile
[INFO]       \- org.springframework:spring-jcl:jar:5.3.21:compile
```