### PR TITLE
MODLOGSAML-148: Bump maxFormAttributeSize from 8192 to 65536

### DIFF
--- a/src/main/java/org/folio/rest/impl/ApiInitializer.java
+++ b/src/main/java/org/folio/rest/impl/ApiInitializer.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import io.vertx.core.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.RestVerticle;
 import org.folio.rest.resource.interfaces.InitAPI;
 
 import javax.net.ssl.HttpsURLConnection;
@@ -16,6 +17,8 @@ public class ApiInitializer implements InitAPI {
 
   private final Logger log = LogManager.getLogger(ApiInitializer.class);
 
+  public static final int MAX_FORM_ATTRIBUTE_SIZE = 64 * 1024;
+
   @Override
   public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> handler) {
     String tacEnv = System.getenv("TRUST_ALL_CERTIFICATES");
@@ -26,6 +29,9 @@ public class ApiInitializer implements InitAPI {
 
     String disableResolver = System.getProperty("vertx.disableDnsResolver");
     log.info("vertx.disableDnsResolver (netty workaround): " + disableResolver);
+
+    // https://issues.folio.org/browse/RMB-856
+    RestVerticle.getHttpServerOptions().setMaxFormAttributeSize(MAX_FORM_ATTRIBUTE_SIZE);
 
     handler.handle(Future.succeededFuture(true));
   }

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -9,10 +9,10 @@ import static io.vertx.core.http.HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD;
 import static io.vertx.core.http.HttpHeaders.ORIGIN;
 import static io.vertx.core.http.HttpHeaders.VARY;
 import static org.pac4j.saml.state.SAML2StateGenerator.SAML_RELAY_STATE_ATTRIBUTE;
+import static org.folio.rest.impl.ApiInitializer.MAX_FORM_ATTRIBUTE_SIZE;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
@@ -183,22 +183,12 @@ public class SamlAPI implements Saml {
 
   private String getRelayState(RoutingContext routingContext, String body) {
     String relayState = routingContext.request().getFormAttribute("RelayState");
-    if (relayState != null) {
-      return relayState;
+
+    if (relayState == null && body.length() > MAX_FORM_ATTRIBUTE_SIZE) {
+      log.error("HTTP body size {} exceeds MAX_FORM_ATTRIBUTE_SIZE={}",
+          body.length(), MAX_FORM_ATTRIBUTE_SIZE);
     }
 
-    // Vert.x doesn't populate form attributes for HTTP/2 requests, we do it manually
-
-    if (body == null) {
-      return null;
-    }
-    String [] attributes = body.split("&");
-    for (String attribute : attributes) {
-      String [] keyVal = attribute.split("=", 2);
-      if (keyVal.length == 2 && "RelayState".equals(keyVal[0])) {
-        relayState = URLDecoder.decode(keyVal[1], StandardCharsets.UTF_8);
-      }
-    }
     return relayState;
   }
 


### PR DESCRIPTION
Some IdPs send a big XML in the SAMLResponse form attribute when calling POST /saml/callback.

This exceeds Vert.x' default maximum of 8192 bytes.

https://samltest.id/ has about 14400 bytes, UChicago has reported "roughly 64K" in RMB-856.