### PR TITLE
MODLOGSAML-151: JDK 17 - InaccessibleObjectException AtomicInteger

### DIFF
--- a/src/test/java/org/folio/util/DumpUtilTest.java
+++ b/src/test/java/org/folio/util/DumpUtilTest.java
@@ -5,9 +5,10 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.okapi.testing.UtilityClassTester;
 import org.junit.Test;
+import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
+import org.springframework.core.io.ByteArrayResource;
 
 public class DumpUtilTest {
 
@@ -21,9 +22,19 @@ public class DumpUtilTest {
     assertThat(DumpUtil.dump(null), is("null"));
   }
 
+  // try dumping the classes used, reflection might cause access failures
+  // https://issues.folio.org/browse/MODLOGSAML-151
+
   @Test
-  public void dumpContent() {
-    assertThat(DumpUtil.dump(new AtomicInteger(9876)), allOf(containsString("AtomicInteger"), containsString("9876")));
+  public void dumpResource() {
+    var resource = new ByteArrayResource(new byte [] {100, 101, 102});
+    assertThat(DumpUtil.dump(resource), allOf(containsString("ByteArrayResource"), containsString("100,101,102")));
+  }
+
+  @Test
+  public void dumpResolver() {
+    var resolver = new SAML2IdentityProviderMetadataResolver(new ByteArrayResource(new byte [] {}), null);
+    assertThat(DumpUtil.dump(resolver), allOf(containsString("SAML2IdentityProviderMetadataResolver")));
   }
 
 }


### PR DESCRIPTION
Use JDK 17 and run "mvn clean install".

Build fails with this error:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private static final jdk.internal.misc.Unsafe java.util.concurrent.atomic.AtomicInteger.U accessible: module java.base does not "opens java.util.concurrent.atomic" to unnamed module @62bd2070
        at org.folio.util.DumpUtilTest.dumpContent(DumpUtilTest.java:26)
```

This is caused by the strong encapsulation of the Java Platform Module System.

Fixing it is easy because it is in the unit test only, not in the production code.