### PR TITLE
MODLOGSAML-161: Use TLSv1.2, not SSL, in SSLContext.getInstance

### DIFF
--- a/src/main/java/org/folio/rest/impl/ApiInitializer.java
+++ b/src/main/java/org/folio/rest/impl/ApiInitializer.java
@@ -64,7 +64,7 @@ public class ApiInitializer implements InitAPI {
 
     // Install the all-trusting trust manager
     try {
-      SSLContext sc = SSLContext.getInstance("SSL");
+      SSLContext sc = SSLContext.getInstance("TLSv1.2");
       sc.init(null, trustAllCerts, new java.security.SecureRandom());
       HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
     } catch (GeneralSecurityException e) {


### PR DESCRIPTION
Encryption that is older than TLSv1.2 is considered insecure.

Task: Use TLSv1.2, not SSL, in SSLContext.getInstance method in ApiInitializer.java.

JDK and OpenSSL already have disabled older encryption. This change is an additional safeguard, but it is mainly used to make static code checkers like Snyk quiet.