### PR TITLE
MODLOGSAML-165: json-smart 2.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,16 @@
       </exclusions>
     </dependency>
 
+    <!-- Fixes Denial of Service (DoS) on deeply nested JSON array or object:
+         https://nvd.nist.gov/vuln/detail/CVE-2023-1370
+         Remove when vertx-pac4j comes with json-smart >= 2.4.10
+    -->
+    <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>2.4.10</version>
+    </dependency>
+
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>


### PR DESCRIPTION
Upgrade json-smart from 2.4.8 to 2.4.10 fixing
Denial of Service (DoS) on deeply nested JSON array or object:
https://nvd.nist.gov/vuln/detail/CVE-2023-1370