### PR TITLE
MODLOGSAML-166: xmlsec 2.3.3, woodstox-core 6.5.0 fixing DoS CVE-2022-40152

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,16 @@
       <version>2.4.10</version>
     </dependency>
 
+    <!-- Fixes Denial of Service (DoS) in com.fasterxml.woodstox:woodstox-core:
+         https://nvd.nist.gov/vuln/detail/CVE-2022-40152
+         Remove when pac4j-saml comes with xmlsec >= 2.3.3 or >= 3.0.2
+    -->
+    <dependency>
+      <groupId>org.apache.santuario</groupId>
+      <artifactId>xmlsec</artifactId>
+      <version>2.3.3</version>
+    </dependency>
+
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>


### PR DESCRIPTION
https://issues.folio.org/browse/MODLOGSAML-166

Upgrade xmlsec from 2.3.0 to 2.3.3.

This indirectly upgrades woodstox-core from 6.2.6 to 6.5.0 fixing Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2022-40152
