### PR TITLE
MODLOGSAML-180: Changes callback to be default rather than callback-with-expiry

### DIFF
--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -72,7 +72,7 @@ public class SamlClientLoader {
             new ByteArrayResource(samlConfiguration.getIdpMetadata().getBytes()) : null;
         final String okapiUrl = samlConfiguration.getOkapiUrl();
         final String callback = samlConfiguration.getCallback() == null ?
-            CALLBACK_WITH_EXPIRY : samlConfiguration.getCallback();
+            CALLBACK : samlConfiguration.getCallback();
 
         if (StringUtils.isBlank(idpUrl)) {
           return Future.failedFuture("There is no IdP configuration stored!");

--- a/src/test/java/org/folio/rest/impl/IdpTest.java
+++ b/src/test/java/org/folio/rest/impl/IdpTest.java
@@ -153,7 +153,7 @@ public class IdpTest {
     var matcher = Pattern.compile("name=\"SAMLResponse\" value=\"([^\"]+)").matcher(body);
     assertThat(matcher.find(), is(true));
 
-     SamlTestHelper.testCookieResponse(cookie, relayState, TEST_PATH, CookieSameSite.LAX.toString(),
+    SamlTestHelper.testCookieResponse(cookie, relayState, TEST_PATH, CookieSameSite.LAX.toString(),
       matcher.group(1), TENANT_HEADER, TOKEN_HEADER, OKAPI_URL_HEADER);
   }
 

--- a/src/test/resources/mock_idptest_post.json
+++ b/src/test/resources/mock_idptest_post.json
@@ -53,6 +53,13 @@
             "configName": "saml",
             "code": "okapi.url",
             "value": "http://localhost:9230"
+          },
+          {
+            "id": "81816efc-63b1-11ee-8c99-0242ac120002",
+            "module": "LOGIN-SAML",
+            "configName": "saml",
+            "code": "saml.callback",
+            "value": "callback-with-expiry"
           }
         ],
         "totalRecords": 6

--- a/src/test/resources/mock_idptest_post_legacy.json
+++ b/src/test/resources/mock_idptest_post_legacy.json
@@ -47,19 +47,13 @@
             "configName": "saml",
             "code": "metadata.invalidated",
             "value": "false"
-          },{
+          },
+          {
             "id": "cb20fa86-affb-4488-8b37-2e8c597fff66",
             "module": "LOGIN-SAML",
             "configName": "saml",
             "code": "okapi.url",
             "value": "http://localhost:9230"
-          },
-          {
-            "id": "81816efc-63b1-11ee-8c99-0242ac120002",
-            "module": "LOGIN-SAML",
-            "configName": "saml",
-            "code": "saml.callback",
-            "value": "callback"
           }
         ],
         "totalRecords": 6

--- a/src/test/resources/mock_idptest_redirect.json
+++ b/src/test/resources/mock_idptest_redirect.json
@@ -54,6 +54,13 @@
             "configName": "saml",
             "code": "okapi.url",
             "value": "http://localhost:9230"
+          },
+          {
+            "id": "81816efc-63b1-11ee-8c99-0242ac120002",
+            "module": "LOGIN-SAML",
+            "configName": "saml",
+            "code": "saml.callback",
+            "value": "callback-with-expiry"
           }
         ],
         "totalRecords": 6

--- a/src/test/resources/mock_idptest_redirect_legacy.json
+++ b/src/test/resources/mock_idptest_redirect_legacy.json
@@ -54,13 +54,6 @@
             "configName": "saml",
             "code": "okapi.url",
             "value": "http://localhost:9230"
-          },
-          {
-            "id": "81816efc-63b1-11ee-8c99-0242ac120002",
-            "module": "LOGIN-SAML",
-            "configName": "saml",
-            "code": "saml.callback",
-            "value": "callback"
           }
         ],
         "totalRecords": 6


### PR DESCRIPTION
Now that RTR won't be the default in stripes it doesn't make sense to make callback-with-expiry the default in this module. When stripes makes RTR the default, we should change this back then.

Having this get into Poppy will make it easier to test for Poppy as well since we no longer need to make the tedious configuration.

There is now a ticket in stripes to make manual configuration unnecessary in Q. That's here: https://issues.folio.org/browse/UITEN-272