### PR TITLE
MODLOGSAML-182: xmlsec 2.3.4 fixing private key in debug level log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,12 +148,14 @@
 
     <!-- Fixes Denial of Service (DoS) in com.fasterxml.woodstox:woodstox-core:
          https://nvd.nist.gov/vuln/detail/CVE-2022-40152
-         Remove when pac4j-saml comes with xmlsec >= 2.3.3 or >= 3.0.2
+         Fixes private key disclose in debug level log:
+         https://nvd.nist.gov/vuln/detail/CVE-2023-44483
+         Remove when pac4j-saml comes with xmlsec >= 2.3.4
     -->
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
-      <version>2.3.3</version>
+      <version>2.3.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
https://issues.folio.org/browse/MODLOGSAML-182

Upgrade santuario:xmlsec from 2.3.3 to 2.3.4 fixing the security issue where a private key may be disclosed in log files when generating an XML Signature and logging with debug level is enabled: https://nvd.nist.gov/vuln/detail/CVE-2023-44483