### PR TITLE
MODLOGSAML-191: Upgrade to Vert.x 4.5.7, RMB 35.2.2, Netty 4.1.108.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <raml-module-builder-version>35.2.0</raml-module-builder-version>
+    <raml-module-builder-version>35.2.2</raml-module-builder-version>
     <generate_routing_context>/saml/callback,/saml/callback-with-expiry,/saml/regenerate,/saml/login,/saml/check,/saml/configuration
     </generate_routing_context>
 
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.5</version>
+        <version>4.5.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-191

The Vert.x upgrade indirectly upgrades Netty from 4.1.107.Final to 4.1.108.Final fixing
https://nvd.nist.gov/vuln/detail/CVE-2024-29025
Allocation of Resources Without Limits or Throttling