### PR TITLE
MODLOGSAML-193: Don't migrate config on fresh install, only on upgrade

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -23,15 +23,26 @@ public class TenantRefAPI extends TenantAPI {
   Future<Integer> loadData(TenantAttributes attributes, String tenantId,
       Map<String, String> headers, Context vertxContext) {
     log.info("TenantRefAPI::loadData");
+    return super.loadData(attributes, tenantId, headers, vertxContext)
+        .compose(result -> {
+          if (attributes.getModuleFrom() == null) {
+            return Future.succeededFuture(0);
+          }
+          return configurationsMigration(headers, vertxContext);
+        });
+  }
+
+  private Future<Integer> configurationsMigration(Map<String, String> headers, Context vertxContext) {
     try {
-      ConfigurationsDao.verifyOkapiHeaders(OkapiHelper.okapiHeadersWithUrlTo(headers));
-      return super.loadData(attributes, tenantId, headers, vertxContext)
-        .compose(result ->
-          new ConfigurationsDaoImpl().dataMigrationLoadData(vertxContext.owner(), OkapiHelper.okapiHeadersWithUrlTo(headers), true));
+      var okapiHeaders = OkapiHelper.okapiHeadersWithUrlTo(headers);
+      ConfigurationsDao.verifyOkapiHeaders(okapiHeaders);
+      return new ConfigurationsDaoImpl().dataMigrationLoadData(vertxContext.owner(), okapiHeaders, true);
     } catch (MissingHeaderException misHeadEx) {
-      String errorMessage = "The Okapi headers are not complete. The data migration from mod-configuration is not possible: " + misHeadEx.getMessage();
+      String errorMessage = "The Okapi headers are not complete. "
+          + "The data migration from mod-configuration is not possible: " + misHeadEx.getMessage();
       log.error("{}", errorMessage);
       return Future.failedFuture(errorMessage);
     }
+
   }
 }

--- a/src/test/java/org/folio/dao/impl/ConfigurationsDaoImplTest.java
+++ b/src/test/java/org/folio/dao/impl/ConfigurationsDaoImplTest.java
@@ -69,7 +69,7 @@ public class ConfigurationsDaoImplTest extends TestBase {
 
     mock.setMockContent("mock_200_empty.json");
     vertx.deployVerticle(mock, okapiOptions)
-      .compose(x -> postTenantExtendedWithToken("http://localhost:" + JSON_MOCK_PORT, PERMISSIONS_HEADER))
+      .compose(x -> postTenantInstall("http://localhost:" + JSON_MOCK_PORT))
       .onComplete(context.asyncAssertSuccess());
   }
 

--- a/src/test/java/org/folio/rest/impl/IdpLegacyTest.java
+++ b/src/test/java/org/folio/rest/impl/IdpLegacyTest.java
@@ -91,7 +91,7 @@ public class IdpLegacyTest extends TestBase{
         .setConfig(new JsonObject().put("http.port", OKAPI_PORT));
     okapi.setMockContent("mock_200_empty.json");
     vertx.deployVerticle(okapi, okapiOptions)
-      .compose(x -> postTenantExtendedWithToken(OKAPI_URL, PERMISSIONS_HEADER))
+      .compose(x -> postTenantInstall(OKAPI_URL))
       .onComplete(context.asyncAssertSuccess());
   }
 

--- a/src/test/java/org/folio/rest/impl/IdpTest.java
+++ b/src/test/java/org/folio/rest/impl/IdpTest.java
@@ -91,7 +91,7 @@ public class IdpTest extends TestBase{
       .setConfig(new JsonObject().put("http.port", OKAPI_PORT));
     okapi.setMockContent("mock_200_empty.json");
     vertx.deployVerticle(okapi, okapiOptions)
-      .compose(x -> postTenantExtendedWithToken(OKAPI_URL, PERMISSIONS_HEADER))
+      .compose(x -> postTenantInstall(OKAPI_URL))
       .onComplete(context.asyncAssertSuccess());
   }
 

--- a/src/test/java/org/folio/rest/impl/SamlAPITest.java
+++ b/src/test/java/org/folio/rest/impl/SamlAPITest.java
@@ -101,7 +101,7 @@ public class SamlAPITest extends TestBase {
     mock.setMockContent("mock_200_empty.json");
     vertx.deployVerticle(IdpMock.class.getName(), idpOptions)
       .compose(x -> vertx.deployVerticle(mock, okapiOptions))
-      .compose(x -> postTenantExtendedWithToken("http://localhost:" + MOCK_SERVER_PORT, PERMISSIONS_HEADER))
+      .compose(x -> postTenantInstall("http://localhost:" + MOCK_SERVER_PORT))
       .onComplete(context.asyncAssertSuccess());
   }
 

--- a/src/test/java/org/folio/rest/impl/TestBase.java
+++ b/src/test/java/org/folio/rest/impl/TestBase.java
@@ -74,17 +74,28 @@ public class TestBase {//contained in "mock_content_with_delete.json"
       .mapEmpty();
   }
 
-  public static Future<Void> postTenantExtendedWithToken(String okapiUrlTo, String permissions) {
+  public static Future<Void> postTenant(String okapiUrlTo, TenantAttributes ta) {
     try {
-      TenantAttributes ta = new TenantAttributes();
-      ta.setModuleTo("mod-login-saml-2.1");
       TenantClient tenantClient = new TenantClientExtended("http://localhost:" + modulePort, okapiUrlTo,
-        TENANT, TENANT, permissions, webClient);
+        TENANT, TENANT, PERMISSIONS_HEADER, webClient);
       return TenantInit.exec(tenantClient, ta, 60000);
     } catch (Exception e) {
       e.printStackTrace(System.err);
       return Future.failedFuture(e);
     }
+  }
+
+  public static Future<Void> postTenantInstall(String okapiUrlTo) {
+    TenantAttributes ta = new TenantAttributes();
+    ta.setModuleTo("mod-login-saml-2.1.99");
+    return postTenant(okapiUrlTo, ta);
+  }
+
+  public static Future<Void> postTenantUpgrade(String okapiUrlTo) {
+    TenantAttributes ta = new TenantAttributes();
+    ta.setModuleFrom("mod-login-saml-2.0.0");
+    ta.setModuleTo("mod-login-saml-2.1.99");
+    return postTenant(okapiUrlTo, ta);
   }
 
   public static int setPreferredPort(int port) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-193

The migration of the configuration values from mod-configuration to mod-login-saml should only be executed when upgrading the mod-login-saml version for a tenant.

It should not be executed when doing a fresh install (enabling mod-login-saml for a tenant).