### PR TITLE
MODLOGSAML-194: pac4j 5.7.7, cryptacular 1.2.7 fixing vulns (b2.8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,32 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Fixes multiple vulnerabilities in org.bouncycastle:bcprov-jdk18on:jar:1.71:
+         https://security.snyk.io/package/maven/org.bouncycastle:bcprov-jdk18on/1.71
+         Remove when pac4j-saml comes with cryptacular >= 1.2.7
+    -->
+    <dependency>
+      <groupId>org.cryptacular</groupId>
+      <artifactId>cryptacular</artifactId>
+      <version>1.2.7</version>
+    </dependency>
+
+    <!-- Fix security issues. Recent opensaml-security-api versions replace
+         org.bouncycastle:bcprov-jdk15on with org.bouncycastle:bcprov-jdk18on
+         fixing vulnerabilities.
+         Remove when pac4j-saml comes with opensaml-security-api >= 4.3.2
+    -->
+    <dependency>
+      <groupId>org.opensaml</groupId>
+      <artifactId>opensaml-security-api</artifactId>
+      <version>4.3.2</version>
     </dependency>
 
     <!-- Fix Allocation of Resources Without Limits or Throttling in
@@ -167,16 +192,6 @@
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
       <version>2.3.4</version>
-    </dependency>
-
-    <!-- Fixes multiple vulnerabilities in org.bouncycastle:bcprov-jdk18on:jar:1.71:
-         https://security.snyk.io/package/maven/org.bouncycastle:bcprov-jdk18on/1.71
-         Remove when pac4j-saml comes with cryptacular >= 1.2.7
-    -->
-    <dependency>
-      <groupId>org.cryptacular</groupId>
-      <artifactId>cryptacular</artifactId>
-      <version>1.2.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Backport the security fix from master to b2.8.