### PR TITLE
MODLOGSAML-197: Okapi-URL path missing from cookie path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>3.9.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/folio/rest/impl/SamlAPI.java
+++ b/src/main/java/org/folio/rest/impl/SamlAPI.java
@@ -257,7 +257,8 @@ public class SamlAPI implements Saml {
               if (isLegacyResponse(tokenSignEndpoint)) {
                 return redirectResponseLegacy(jsonResponse, stripesBaseUrl, originalUrl);
               } else {
-                return redirectResponse(jsonResponse, stripesBaseUrl, originalUrl);
+                var okapiPath = UrlUtil.getPathFromOkapiUrl(parsedHeaders.getUrl());
+                return redirectResponse(jsonResponse, stripesBaseUrl, originalUrl, okapiPath);
               }
             });
           });
@@ -321,7 +322,9 @@ public class SamlAPI implements Saml {
     return PostSamlCallbackResponse.respond302(headers);
   }
 
-  private Response redirectResponse(JsonObject jsonObject, URI stripesBaseUrl, URI originalUrl) {
+  private Response redirectResponse(JsonObject jsonObject,
+      URI stripesBaseUrl, URI originalUrl, String okapiPath) {
+
     String accessToken = jsonObject.getString(ACCESS_TOKEN);
     String refreshToken = jsonObject.getString(REFRESH_TOKEN);
     String accessTokenExpiration = jsonObject.getString(ACCESS_TOKEN_EXPIRATION);
@@ -339,13 +342,14 @@ public class SamlAPI implements Saml {
 
     // NOTE RMB doesn't support sending multiple headers with the same key so we
     // make our own response.
-    return Response.status(302).header(SET_COOKIE, accessTokenCookie(accessToken, accessTokenExpiration))
-      .header(SET_COOKIE, refreshTokenCookie(refreshToken, refreshTokenExpiration))
+    return Response.status(302)
+      .header(SET_COOKIE, accessTokenCookie(accessToken, accessTokenExpiration, okapiPath))
+      .header(SET_COOKIE, refreshTokenCookie(refreshToken, refreshTokenExpiration, okapiPath))
       .header(LOCATION, location)
       .build();
   }
 
-  private String refreshTokenCookie(String refreshToken, String refreshTokenExpiration) {
+  private String refreshTokenCookie(String refreshToken, String refreshTokenExpiration, String okapiPath) {
     // The refresh token expiration is the time after which the token will be
     // considered expired.
     var exp = Instant.parse(refreshTokenExpiration).getEpochSecond();
@@ -360,7 +364,7 @@ public class SamlAPI implements Saml {
     var rtCookie = Cookie.cookie(FOLIO_REFRESH_TOKEN, refreshToken)
       .setMaxAge(ttlSeconds)
       .setSecure(true)
-      .setPath("/authn")
+      .setPath(okapiPath + "/authn")
       .setHttpOnly(true)
       .setSameSite(CookieSameSiteConfig.get())
       .setDomain(null)
@@ -371,7 +375,7 @@ public class SamlAPI implements Saml {
     return rtCookie;
   }
 
-  private String accessTokenCookie(String accessToken, String accessTokenExpiration) {
+  private String accessTokenCookie(String accessToken, String accessTokenExpiration, String okapiPath) {
     // The refresh token expiration is the time after which the token will be
     // considered expired.
     var exp = Instant.parse(accessTokenExpiration).getEpochSecond();
@@ -386,7 +390,7 @@ public class SamlAPI implements Saml {
     var atCookie = Cookie.cookie(FOLIO_ACCESS_TOKEN, accessToken)
       .setMaxAge(ttlSeconds)
       .setSecure(true)
-      .setPath("/")
+      .setPath(okapiPath + "/")
       .setHttpOnly(true)
       .setSameSite(CookieSameSiteConfig.get())
       .encode();

--- a/src/main/java/org/folio/util/UrlUtil.java
+++ b/src/main/java/org/folio/util/UrlUtil.java
@@ -1,7 +1,13 @@
 package org.folio.util;
 
+import java.io.UncheckedIOException;
 import java.net.ConnectException;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -12,9 +18,28 @@ import io.vertx.ext.web.client.WebClient;
  * @author rsass
  */
 public class UrlUtil {
+  private static final Logger logger = LogManager.getLogger(UrlUtil.class);
 
   private UrlUtil() {
 
+  }
+
+  /**
+   * Return the path component of the okapiUrl without tailing '/',
+   * return empty string on parse error.
+   */
+  public static String getPathFromOkapiUrl(String okapiUrl) {
+    try {
+      var path = new URL(okapiUrl).getPath();
+      if (path.endsWith("/")) {
+        return path.substring(0, path.length() - 1);
+      }
+      return path;
+    } catch (MalformedURLException e) {
+      var message = "Malformed Okapi URL: " + okapiUrl;
+      logger.error("{}", message, e);
+      throw new UncheckedIOException(message, e);
+    }
   }
 
   public static URI parseBaseUrl(URI originalUrl) {

--- a/src/test/java/org/folio/util/UrlUtilTest.java
+++ b/src/test/java/org/folio/util/UrlUtilTest.java
@@ -1,17 +1,22 @@
 package org.folio.util;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.DeploymentOptions;
@@ -48,6 +53,23 @@ public class UrlUtilTest {
   @AfterClass
   public static void afterOnce(TestContext context) {
     mockVertx.close(context.asyncAssertSuccess());
+  }
+
+  void assertMalformedUrlException(ThrowingRunnable runnable) {
+    var e = assertThrows(UncheckedIOException.class, runnable);
+    assertThat(e.getMessage(), startsWith("Malformed Okapi URL: "));
+    assertThat(e.getCause(), instanceOf(MalformedURLException.class));
+  }
+
+  @Test
+  public void getPathFromOkapiUrl() {
+    assertMalformedUrlException(() -> UrlUtil.getPathFromOkapiUrl(null));
+    assertMalformedUrlException(() -> UrlUtil.getPathFromOkapiUrl(""));
+    assertMalformedUrlException(() -> UrlUtil.getPathFromOkapiUrl(":"));
+    assertThat(UrlUtil.getPathFromOkapiUrl("https://localhost"), is(""));
+    assertThat(UrlUtil.getPathFromOkapiUrl("https://localhost/"), is(""));
+    assertThat(UrlUtil.getPathFromOkapiUrl("https://localhost/okapi"), is("/okapi"));
+    assertThat(UrlUtil.getPathFromOkapiUrl("https://localhost/okapi/"), is("/okapi"));
   }
 
   @Test


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-197

Expected cookie path when passing Okapi-URL https://folio.example.com/okapi :

* /okapi/authn
* /okapi

Actual cookie path when passing Okapi-URL https://folio.example.com/okapi :

* /authn
* /

Fix: Take path from Okapi-URL and prepend to /authn or / when building cookie path.