### PR TITLE
MODLOGSAML-198: limit=1000 for GET /configurations/entries

### DIFF
--- a/src/main/java/org/folio/config/ConfigurationsClient.java
+++ b/src/main/java/org/folio/config/ConfigurationsClient.java
@@ -122,7 +122,7 @@ public class ConfigurationsClient {
     CharSequence encodedQuery = PercentCodec.encode(query);
 
     return WebClientFactory.getWebClient(vertx)
-      .getAbs(okapiHeaders.getUrl() + CONFIGURATIONS_ENTRIES_ENDPOINT_URL + "?query=" + encodedQuery)
+      .getAbs(okapiHeaders.getUrl() + CONFIGURATIONS_ENTRIES_ENDPOINT_URL + "?limit=1000&query=" + encodedQuery)
       .putHeader(XOkapiHeaders.TOKEN, okapiHeaders.getToken())
       .putHeader(XOkapiHeaders.URL, okapiHeaders.getUrl())
       .putHeader(XOkapiHeaders.TENANT, okapiHeaders.getTenant())

--- a/src/main/java/org/folio/util/OkapiHelper.java
+++ b/src/main/java/org/folio/util/OkapiHelper.java
@@ -51,7 +51,7 @@ public class OkapiHelper {
   * For example in the class ConfigurationsClient:
   * public static Future<JsonArray> ConfigurationsClient.checkConfig(Vertx vertx, OkapiHeaders okapiHeaders,String query)
   * return WebClientFactory.getWebClient(vertx)
-  *   .getAbs(okapiHeaders.getUrl() + CONFIGURATIONS_ENTRIES_ENDPOINT_URL + "?query=" + encodedQuery) ....
+  *   .getAbs(okapiHeaders.getUrl() + CONFIGURATIONS_ENTRIES_ENDPOINT_URL + "?limit=1000&query=" + encodedQuery) ....
   */
   public static OkapiHeaders okapiHeadersWithUrlTo(Map<String, String> parsedHeaders ) {
     OkapiHeaders headers = okapiHeaders(parsedHeaders);

--- a/src/test/java/org/folio/util/MockJsonExtended.java
+++ b/src/test/java/org/folio/util/MockJsonExtended.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class MockJsonExtended extends MockJson {
   private static final Logger log = LogManager.getLogger(MockJsonExtended.class);
-  private static final String PARTIAL_URL = "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29";
+  private static final String PARTIAL_URL = "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29";
   private static final String RECEIVED_DATA_CONSTANT = "receivedData";
   private static final String CONFIGS_CONSTANT = "configs";
   private static final String URL_CONSTANT = "url";

--- a/src/test/resources/after_regenerate.json
+++ b/src/test/resources/after_regenerate.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -62,7 +62,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -71,7 +71,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -88,7 +88,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -105,7 +105,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_200_empty.json
+++ b/src/test/resources/mock_200_empty.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
         "receivedData": {

--- a/src/test/resources/mock_200_null.json
+++ b/src/test/resources/mock_200_null.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
         "receivedData": {}

--- a/src/test/resources/mock_400.json
+++ b/src/test/resources/mock_400.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 400,
       "receivedData": { }

--- a/src/test/resources/mock_content.json
+++ b/src/test/resources/mock_content.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -62,7 +62,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -71,7 +71,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.metadata%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -88,7 +88,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -105,7 +105,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -122,7 +122,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_content_legacy.json
+++ b/src/test/resources/mock_content_legacy.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -69,7 +69,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -78,7 +78,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.metadata%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -95,7 +95,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -112,7 +112,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.callback%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.callback%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -129,7 +129,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -146,7 +146,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_content_no_keystore.json
+++ b/src/test/resources/mock_content_no_keystore.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -55,7 +55,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -64,7 +64,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -73,7 +73,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -90,7 +90,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -107,7 +107,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_content_with_delete.json
+++ b/src/test/resources/mock_content_with_delete.json
@@ -1,7 +1,7 @@
 {
     "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -98,7 +98,7 @@
       "status": 204
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%idp.metadata%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -115,7 +115,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Didp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Didp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -132,7 +132,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dmetadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dmetadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -149,7 +149,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Duser.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Duser.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -158,7 +158,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dsaml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dsaml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -167,7 +167,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.file%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.file%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -184,7 +184,7 @@
        }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.password%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.password%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -201,7 +201,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.privatekey.password%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dkeystore.privatekey.password%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -218,7 +218,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dsaml.binding%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dsaml.binding%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -235,7 +235,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dokapi.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3Dokapi.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_content_with_metadata.json
+++ b/src/test/resources/mock_content_with_metadata.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -63,7 +63,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -72,13 +72,13 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
       "method": "get",
       "status": 200,
       "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" ID=\"SAMLtestIdP\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:shibmd=\"urn:mace:shibboleth:metadata:1.0\" xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xmlns:mdui=\"urn:oasis:names:tc:SAML:metadata:ui\" validUntil=\"2100-01-01T00:00:42Z\" entityID=\"https://samltest.id/saml/idp\">\n\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0\">\n\n        <Extensions>\n<!-- An enumeration of the domains this IdP is able to assert scoped attributes, which are\ntypically those with a @ delimiter, like mail.  Most IdP's serve only a single domain.  It's crucial\nfor the SP to check received attribute values match permitted domains to prevent a recognized IdP from\nsending attribute values for which a different recognized IdP is authoritative. -->\n            <shibmd:Scope regexp=\"false\">samltest.id</shibmd:Scope>\n\n<!-- Display information about this IdP that can be used by SP's and discovery\nservices to identify the IdP meaningfully for end users -->\n            <mdui:UIInfo>\n                <mdui:DisplayName xml:lang=\"en\">SAMLtest IdP</mdui:DisplayName>\n                <mdui:Description xml:lang=\"en\">A free and basic IdP for testing SAML deployments</mdui:Description>\n                <mdui:Logo height=\"90\" width=\"225\">https://samltest.id/saml/logo.png</mdui:Logo>\n            </mdui:UIInfo>\n        </Extensions>\n\n        <KeyDescriptor use=\"signing\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDETCCAfmgAwIBAgIUZRpDhkNKl5eWtJqk0Bu1BgTTargwDQYJKoZIhvcNAQEL\nBQAwFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwHhcNMTgwODI0MjExNDEwWhcNMzgw\nODI0MjExNDEwWjAWMRQwEgYDVQQDDAtzYW1sdGVzdC5pZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAJrh9/PcDsiv3UeL8Iv9rf4WfLPxuOm9W6aCntEA\n8l6c1LQ1Zyrz+Xa/40ZgP29ENf3oKKbPCzDcc6zooHMji2fBmgXp6Li3fQUzu7yd\n+nIC2teejijVtrNLjn1WUTwmqjLtuzrKC/ePoZyIRjpoUxyEMJopAd4dJmAcCq/K\nk2eYX9GYRlqvIjLFoGNgy2R4dWwAKwljyh6pdnPUgyO/WjRDrqUBRFrLQJorR2kD\nc4seZUbmpZZfp4MjmWMDgyGM1ZnR0XvNLtYeWAyt0KkSvFoOMjZUeVK/4xR74F8e\n8ToPqLmZEg9ZUx+4z2KjVK00LpdRkH9Uxhh03RQ0FabHW6UCAwEAAaNXMFUwHQYD\nVR0OBBYEFJDbe6uSmYQScxpVJhmt7PsCG4IeMDQGA1UdEQQtMCuCC3NhbWx0ZXN0\nLmlkhhxodHRwczovL3NhbWx0ZXN0LmlkL3NhbWwvaWRwMA0GCSqGSIb3DQEBCwUA\nA4IBAQBNcF3zkw/g51q26uxgyuy4gQwnSr01Mhvix3Dj/Gak4tc4XwvxUdLQq+jC\ncxr2Pie96klWhY/v/JiHDU2FJo9/VWxmc/YOk83whvNd7mWaNMUsX3xGv6AlZtCO\nL3JhCpHjiN+kBcMgS5jrtGgV1Lz3/1zpGxykdvS0B4sPnFOcaCwHe2B9SOCWbDAN\nJXpTjz1DmJO4ImyWPJpN1xsYKtm67Pefxmn0ax0uE2uuzq25h0xbTkqIQgJzyoE/\nDPkBFK1vDkMfAW11dQ0BXatEnW7Gtkc0lh2/PIbHWj4AzxYMyBf5Gy6HSVOftwjC\nvoQR2qr2xJBixsg+MIORKtmKHLfU\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n        <KeyDescriptor use=\"signing\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDEjCCAfqgAwIBAgIVAMECQ1tjghafm5OxWDh9hwZfxthWMA0GCSqGSIb3DQEB\nCwUAMBYxFDASBgNVBAMMC3NhbWx0ZXN0LmlkMB4XDTE4MDgyNDIxMTQwOVoXDTM4\nMDgyNDIxMTQwOVowFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQC0Z4QX1NFKs71ufbQwoQoW7qkNAJRIANGA4iM0\nThYghul3pC+FwrGv37aTxWXfA1UG9njKbbDreiDAZKngCgyjxj0uJ4lArgkr4AOE\njj5zXA81uGHARfUBctvQcsZpBIxDOvUUImAl+3NqLgMGF2fktxMG7kX3GEVNc1kl\nbN3dfYsaw5dUrw25DheL9np7G/+28GwHPvLb4aptOiONbCaVvh9UMHEA9F7c0zfF\n/cL5fOpdVa54wTI0u12CsFKt78h6lEGG5jUs/qX9clZncJM7EFkN3imPPy+0HC8n\nspXiH/MZW8o2cqWRkrw3MzBZW3Ojk5nQj40V6NUbjb7kfejzAgMBAAGjVzBVMB0G\nA1UdDgQWBBQT6Y9J3Tw/hOGc8PNV7JEE4k2ZNTA0BgNVHREELTArggtzYW1sdGVz\ndC5pZIYcaHR0cHM6Ly9zYW1sdGVzdC5pZC9zYW1sL2lkcDANBgkqhkiG9w0BAQsF\nAAOCAQEASk3guKfTkVhEaIVvxEPNR2w3vWt3fwmwJCccW98XXLWgNbu3YaMb2RSn\n7Th4p3h+mfyk2don6au7Uyzc1Jd39RNv80TG5iQoxfCgphy1FYmmdaSfO8wvDtHT\nTNiLArAxOYtzfYbzb5QrNNH/gQEN8RJaEf/g/1GTw9x/103dSMK0RXtl+fRs2nbl\nD1JJKSQ3AdhxK/weP3aUPtLxVVJ9wMOQOfcy02l+hHMb6uAjsPOpOVKqi3M8XmcU\nZOpx4swtgGdeoSpeRyrtMvRwdcciNBp9UZome44qZAYH1iqrpmmjsfI9pJItsgWu\n3kXPjhSfj1AJGR1l9JGvJrHki1iHTA==\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n        <KeyDescriptor use=\"encryption\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDEjCCAfqgAwIBAgIVAPVbodo8Su7/BaHXUHykx0Pi5CFaMA0GCSqGSIb3DQEB\nCwUAMBYxFDASBgNVBAMMC3NhbWx0ZXN0LmlkMB4XDTE4MDgyNDIxMTQwOVoXDTM4\nMDgyNDIxMTQwOVowFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCQb+1a7uDdTTBBFfwOUun3IQ9nEuKM98SmJDWa\nMwM877elswKUTIBVh5gB2RIXAPZt7J/KGqypmgw9UNXFnoslpeZbA9fcAqqu28Z4\nsSb2YSajV1ZgEYPUKvXwQEmLWN6aDhkn8HnEZNrmeXihTFdyr7wjsLj0JpQ+VUlc\n4/J+hNuU7rGYZ1rKY8AA34qDVd4DiJ+DXW2PESfOu8lJSOteEaNtbmnvH8KlwkDs\n1NvPTsI0W/m4SK0UdXo6LLaV8saIpJfnkVC/FwpBolBrRC/Em64UlBsRZm2T89ca\nuzDee2yPUvbBd5kLErw+sC7i4xXa2rGmsQLYcBPhsRwnmBmlAgMBAAGjVzBVMB0G\nA1UdDgQWBBRZ3exEu6rCwRe5C7f5QrPcAKRPUjA0BgNVHREELTArggtzYW1sdGVz\ndC5pZIYcaHR0cHM6Ly9zYW1sdGVzdC5pZC9zYW1sL2lkcDANBgkqhkiG9w0BAQsF\nAAOCAQEABZDFRNtcbvIRmblnZItoWCFhVUlq81ceSQddLYs8DqK340//hWNAbYdj\nWcP85HhIZnrw6NGCO4bUipxZXhiqTA/A9d1BUll0vYB8qckYDEdPDduYCOYemKkD\ndmnHMQWs9Y6zWiYuNKEJ9mf3+1N8knN/PK0TYVjVjXAf2CnOETDbLtlj6Nqb8La3\nsQkYmU+aUdopbjd5JFFwbZRaj6KiHXHtnIRgu8sUXNPrgipUgZUOVhP0C0N5OfE4\nJW8ZBrKgQC/6vJ2rSa9TlzI6JAa5Ww7gMXMP9M+cJUNQklcq+SBnTK8G+uBHgPKR\nzBDsMIEzRtQZm4GIoHJae4zmnCekkQ==\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n\n<!-- An endpoint for artifact resolution.  Please see Wikipedia for more details about SAML\n     artifacts and when you may find them useful. -->\n\n        <ArtifactResolutionService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\"https://samltest.id/idp/profile/SAML2/SOAP/ArtifactResolution\" index=\"1\" />\n\n<!-- A set of endpoints where the IdP can receive logout messages. These must match the public\nfacing addresses if this IdP is hosted behind a reverse proxy.  -->\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://samltest.id/idp/profile/SAML2/Redirect/SLO\"/>\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://samltest.id/idp/profile/SAML2/POST/SLO\"/>\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\" Location=\"https://samltest.id/idp/profile/SAML2/POST-SimpleSign/SLO\"/>\n\n<!-- A set of endpoints the SP can send AuthnRequests to in order to trigger user authentication. -->\n        <SingleSignOnService Binding=\"urn:mace:shibboleth:1.0:profiles:AuthnRequest\" Location=\"https://samltest.id/idp/profile/Shibboleth/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://samltest.id/idp/profile/SAML2/POST/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\" Location=\"https://samltest.id/idp/profile/SAML2/POST-SimpleSign/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://samltest.id/idp/profile/SAML2/Redirect/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\"https://samltest.id/idp/profile/SAML2/SOAP/ECP\"/>\n\n    </IDPSSODescriptor>\n\n</EntityDescriptor>\n"
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -95,7 +95,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -112,7 +112,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_content_with_metadata_legacy.json
+++ b/src/test/resources/mock_content_with_metadata_legacy.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -62,7 +62,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -71,13 +71,13 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML+AND+configName%3D%3Dsaml+AND+code%3D%3D+idp.metadata%29",
       "method": "get",
       "status": 200,
       "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" ID=\"SAMLtestIdP\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" xmlns:shibmd=\"urn:mace:shibboleth:metadata:1.0\" xmlns:xml=\"http://www.w3.org/XML/1998/namespace\" xmlns:mdui=\"urn:oasis:names:tc:SAML:metadata:ui\" validUntil=\"2100-01-01T00:00:42Z\" entityID=\"https://samltest.id/saml/idp\">\n\n    <IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol urn:oasis:names:tc:SAML:1.1:protocol urn:mace:shibboleth:1.0\">\n\n        <Extensions>\n<!-- An enumeration of the domains this IdP is able to assert scoped attributes, which are\ntypically those with a @ delimiter, like mail.  Most IdP's serve only a single domain.  It's crucial\nfor the SP to check received attribute values match permitted domains to prevent a recognized IdP from\nsending attribute values for which a different recognized IdP is authoritative. -->\n            <shibmd:Scope regexp=\"false\">samltest.id</shibmd:Scope>\n\n<!-- Display information about this IdP that can be used by SP's and discovery\nservices to identify the IdP meaningfully for end users -->\n            <mdui:UIInfo>\n                <mdui:DisplayName xml:lang=\"en\">SAMLtest IdP</mdui:DisplayName>\n                <mdui:Description xml:lang=\"en\">A free and basic IdP for testing SAML deployments</mdui:Description>\n                <mdui:Logo height=\"90\" width=\"225\">https://samltest.id/saml/logo.png</mdui:Logo>\n            </mdui:UIInfo>\n        </Extensions>\n\n        <KeyDescriptor use=\"signing\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDETCCAfmgAwIBAgIUZRpDhkNKl5eWtJqk0Bu1BgTTargwDQYJKoZIhvcNAQEL\nBQAwFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwHhcNMTgwODI0MjExNDEwWhcNMzgw\nODI0MjExNDEwWjAWMRQwEgYDVQQDDAtzYW1sdGVzdC5pZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAJrh9/PcDsiv3UeL8Iv9rf4WfLPxuOm9W6aCntEA\n8l6c1LQ1Zyrz+Xa/40ZgP29ENf3oKKbPCzDcc6zooHMji2fBmgXp6Li3fQUzu7yd\n+nIC2teejijVtrNLjn1WUTwmqjLtuzrKC/ePoZyIRjpoUxyEMJopAd4dJmAcCq/K\nk2eYX9GYRlqvIjLFoGNgy2R4dWwAKwljyh6pdnPUgyO/WjRDrqUBRFrLQJorR2kD\nc4seZUbmpZZfp4MjmWMDgyGM1ZnR0XvNLtYeWAyt0KkSvFoOMjZUeVK/4xR74F8e\n8ToPqLmZEg9ZUx+4z2KjVK00LpdRkH9Uxhh03RQ0FabHW6UCAwEAAaNXMFUwHQYD\nVR0OBBYEFJDbe6uSmYQScxpVJhmt7PsCG4IeMDQGA1UdEQQtMCuCC3NhbWx0ZXN0\nLmlkhhxodHRwczovL3NhbWx0ZXN0LmlkL3NhbWwvaWRwMA0GCSqGSIb3DQEBCwUA\nA4IBAQBNcF3zkw/g51q26uxgyuy4gQwnSr01Mhvix3Dj/Gak4tc4XwvxUdLQq+jC\ncxr2Pie96klWhY/v/JiHDU2FJo9/VWxmc/YOk83whvNd7mWaNMUsX3xGv6AlZtCO\nL3JhCpHjiN+kBcMgS5jrtGgV1Lz3/1zpGxykdvS0B4sPnFOcaCwHe2B9SOCWbDAN\nJXpTjz1DmJO4ImyWPJpN1xsYKtm67Pefxmn0ax0uE2uuzq25h0xbTkqIQgJzyoE/\nDPkBFK1vDkMfAW11dQ0BXatEnW7Gtkc0lh2/PIbHWj4AzxYMyBf5Gy6HSVOftwjC\nvoQR2qr2xJBixsg+MIORKtmKHLfU\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n        <KeyDescriptor use=\"signing\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDEjCCAfqgAwIBAgIVAMECQ1tjghafm5OxWDh9hwZfxthWMA0GCSqGSIb3DQEB\nCwUAMBYxFDASBgNVBAMMC3NhbWx0ZXN0LmlkMB4XDTE4MDgyNDIxMTQwOVoXDTM4\nMDgyNDIxMTQwOVowFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQC0Z4QX1NFKs71ufbQwoQoW7qkNAJRIANGA4iM0\nThYghul3pC+FwrGv37aTxWXfA1UG9njKbbDreiDAZKngCgyjxj0uJ4lArgkr4AOE\njj5zXA81uGHARfUBctvQcsZpBIxDOvUUImAl+3NqLgMGF2fktxMG7kX3GEVNc1kl\nbN3dfYsaw5dUrw25DheL9np7G/+28GwHPvLb4aptOiONbCaVvh9UMHEA9F7c0zfF\n/cL5fOpdVa54wTI0u12CsFKt78h6lEGG5jUs/qX9clZncJM7EFkN3imPPy+0HC8n\nspXiH/MZW8o2cqWRkrw3MzBZW3Ojk5nQj40V6NUbjb7kfejzAgMBAAGjVzBVMB0G\nA1UdDgQWBBQT6Y9J3Tw/hOGc8PNV7JEE4k2ZNTA0BgNVHREELTArggtzYW1sdGVz\ndC5pZIYcaHR0cHM6Ly9zYW1sdGVzdC5pZC9zYW1sL2lkcDANBgkqhkiG9w0BAQsF\nAAOCAQEASk3guKfTkVhEaIVvxEPNR2w3vWt3fwmwJCccW98XXLWgNbu3YaMb2RSn\n7Th4p3h+mfyk2don6au7Uyzc1Jd39RNv80TG5iQoxfCgphy1FYmmdaSfO8wvDtHT\nTNiLArAxOYtzfYbzb5QrNNH/gQEN8RJaEf/g/1GTw9x/103dSMK0RXtl+fRs2nbl\nD1JJKSQ3AdhxK/weP3aUPtLxVVJ9wMOQOfcy02l+hHMb6uAjsPOpOVKqi3M8XmcU\nZOpx4swtgGdeoSpeRyrtMvRwdcciNBp9UZome44qZAYH1iqrpmmjsfI9pJItsgWu\n3kXPjhSfj1AJGR1l9JGvJrHki1iHTA==\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n        <KeyDescriptor use=\"encryption\">\n            <ds:KeyInfo>\n                    <ds:X509Data>\n                        <ds:X509Certificate>\nMIIDEjCCAfqgAwIBAgIVAPVbodo8Su7/BaHXUHykx0Pi5CFaMA0GCSqGSIb3DQEB\nCwUAMBYxFDASBgNVBAMMC3NhbWx0ZXN0LmlkMB4XDTE4MDgyNDIxMTQwOVoXDTM4\nMDgyNDIxMTQwOVowFjEUMBIGA1UEAwwLc2FtbHRlc3QuaWQwggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQCQb+1a7uDdTTBBFfwOUun3IQ9nEuKM98SmJDWa\nMwM877elswKUTIBVh5gB2RIXAPZt7J/KGqypmgw9UNXFnoslpeZbA9fcAqqu28Z4\nsSb2YSajV1ZgEYPUKvXwQEmLWN6aDhkn8HnEZNrmeXihTFdyr7wjsLj0JpQ+VUlc\n4/J+hNuU7rGYZ1rKY8AA34qDVd4DiJ+DXW2PESfOu8lJSOteEaNtbmnvH8KlwkDs\n1NvPTsI0W/m4SK0UdXo6LLaV8saIpJfnkVC/FwpBolBrRC/Em64UlBsRZm2T89ca\nuzDee2yPUvbBd5kLErw+sC7i4xXa2rGmsQLYcBPhsRwnmBmlAgMBAAGjVzBVMB0G\nA1UdDgQWBBRZ3exEu6rCwRe5C7f5QrPcAKRPUjA0BgNVHREELTArggtzYW1sdGVz\ndC5pZIYcaHR0cHM6Ly9zYW1sdGVzdC5pZC9zYW1sL2lkcDANBgkqhkiG9w0BAQsF\nAAOCAQEABZDFRNtcbvIRmblnZItoWCFhVUlq81ceSQddLYs8DqK340//hWNAbYdj\nWcP85HhIZnrw6NGCO4bUipxZXhiqTA/A9d1BUll0vYB8qckYDEdPDduYCOYemKkD\ndmnHMQWs9Y6zWiYuNKEJ9mf3+1N8knN/PK0TYVjVjXAf2CnOETDbLtlj6Nqb8La3\nsQkYmU+aUdopbjd5JFFwbZRaj6KiHXHtnIRgu8sUXNPrgipUgZUOVhP0C0N5OfE4\nJW8ZBrKgQC/6vJ2rSa9TlzI6JAa5Ww7gMXMP9M+cJUNQklcq+SBnTK8G+uBHgPKR\nzBDsMIEzRtQZm4GIoHJae4zmnCekkQ==\n                        </ds:X509Certificate>\n                    </ds:X509Data>\n            </ds:KeyInfo>\n\n        </KeyDescriptor>\n\n<!-- An endpoint for artifact resolution.  Please see Wikipedia for more details about SAML\n     artifacts and when you may find them useful. -->\n\n        <ArtifactResolutionService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\"https://samltest.id/idp/profile/SAML2/SOAP/ArtifactResolution\" index=\"1\" />\n\n<!-- A set of endpoints where the IdP can receive logout messages. These must match the public\nfacing addresses if this IdP is hosted behind a reverse proxy.  -->\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://samltest.id/idp/profile/SAML2/Redirect/SLO\"/>\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://samltest.id/idp/profile/SAML2/POST/SLO\"/>\n        <SingleLogoutService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\" Location=\"https://samltest.id/idp/profile/SAML2/POST-SimpleSign/SLO\"/>\n\n<!-- A set of endpoints the SP can send AuthnRequests to in order to trigger user authentication. -->\n        <SingleSignOnService Binding=\"urn:mace:shibboleth:1.0:profiles:AuthnRequest\" Location=\"https://samltest.id/idp/profile/Shibboleth/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://samltest.id/idp/profile/SAML2/POST/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST-SimpleSign\" Location=\"https://samltest.id/idp/profile/SAML2/POST-SimpleSign/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://samltest.id/idp/profile/SAML2/Redirect/SSO\"/>\n        <SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:SOAP\" Location=\"https://samltest.id/idp/profile/SAML2/SOAP/ECP\"/>\n\n    </IDPSSODescriptor>\n\n</EntityDescriptor>\n"
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -94,7 +94,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -111,7 +111,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_example_entries.json
+++ b/src/test/resources/mock_example_entries.json
@@ -1,7 +1,7 @@
 {
     "mocks": [
       {
-        "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+        "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
         "method": "get",
         "status": 200,
         "receivedData": {

--- a/src/test/resources/mock_idptest_post.json
+++ b/src/test/resources/mock_idptest_post.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_idptest_post_legacy.json
+++ b/src/test/resources/mock_idptest_post_legacy.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_idptest_redirect.json
+++ b/src/test/resources/mock_idptest_redirect.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_idptest_redirect_legacy.json
+++ b/src/test/resources/mock_idptest_redirect_legacy.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_metadata_bogus.json
+++ b/src/test/resources/mock_metadata_bogus.json
@@ -7,7 +7,7 @@
       "receivedData": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><EntityDescriptor xmlns=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"\"></EntityDescriptor>"
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_multiple_user_tenant.json
+++ b/src/test/resources/mock_multiple_user_tenant.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_noidp.json
+++ b/src/test/resources/mock_noidp.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_nokeystore.json
+++ b/src/test/resources/mock_nokeystore.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -55,7 +55,7 @@
       "sendData": {}
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.attribute%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -64,7 +64,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20idp.url%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -81,7 +81,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20metadata.invalidated%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -98,7 +98,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20user.property%29",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -137,7 +137,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.binding%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.binding%29",
       "method" : "get",
       "status" : 200,
       "receivedData": {
@@ -145,12 +145,12 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.binding%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20saml.binding%29",
       "method" : "put",
       "status" : 204
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.file%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.file%29",
       "method" : "get",
       "status" : 200,
       "receivedData": {
@@ -158,7 +158,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.password%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.password%29",
       "method" : "get",
       "status" : 200,
       "receivedData": {
@@ -166,7 +166,7 @@
       }
     },
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.privatekey.password%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%20AND%20code%3D%3D%20keystore.privatekey.password%29",
       "method" : "get",
       "status" : 200,
       "receivedData": {

--- a/src/test/resources/mock_nouser.json
+++ b/src/test/resources/mock_nouser.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_one_user_tenant.json
+++ b/src/test/resources/mock_one_user_tenant.json
@@ -1,7 +1,7 @@
 {
   "mocks": [
     {
-      "url": "/configurations/entries?query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
+      "url": "/configurations/entries?limit=1000&query=%28module%3D%3DLOGIN-SAML%20AND%20configName%3D%3Dsaml%29",
       "method": "get",
       "status": 200,
       "receivedData": {


### PR DESCRIPTION
Increase the default limit of 10 to 1000 when calling GET /configurations/entries because https://folio-org.atlassian.net/browse/MODLOGSAML-192 "Allow `callback` endpoint to return RTR tokens when configured" has increased the number of configuration records so that a limit of 10 is too small.