### PR TITLE
MODLOGSAML-202: Add modulePermissions to POST /_/tenant API

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -111,8 +111,13 @@
       "handlers" : [
         {
           "methods" : [ "POST" ],
-          "pathPattern" : "/_/tenant"
-        }, {
+          "pathPattern" : "/_/tenant",
+          "modulePermissions": [
+            "configuration.entries.collection.get",
+            "configuration.entries.item.post",
+            "configuration.entries.item.put"
+          ]
+         }, {
           "methods" : [ "GET", "DELETE" ],
           "pathPattern" : "/_/tenant/{id}"
         }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-202

For migration we need configuration.entries.* permissions to fetch the configuration from mod-configuration.

Add them as "modulePermissions" to the POST /_/tenant API.