### PR TITLE
MODLOGSAML-208: Bump maximumAuthenticationLifetime from 5 to 8 hours

### DIFF
--- a/src/main/java/org/folio/config/SamlClientLoader.java
+++ b/src/main/java/org/folio/config/SamlClientLoader.java
@@ -177,7 +177,7 @@ public class SamlClientLoader {
     if (idpMetadata != null) {
       cfg.setIdentityProviderMetadataResource(idpMetadata);
     }
-    cfg.setMaximumAuthenticationLifetime(18000);
+    cfg.setMaximumAuthenticationLifetime(28800);  // 8 hours
 
     return cfg;
   }
@@ -194,7 +194,7 @@ public class SamlClientLoader {
     if (idpMetadata != null) {
       cfg.setIdentityProviderMetadataResource(idpMetadata);
     }
-    cfg.setMaximumAuthenticationLifetime(18000);
+    cfg.setMaximumAuthenticationLifetime(28800);  // 8 hours
 
     return cfg;
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-208

ADFS IDP has a lifetime of 8 hours.  Using a smaller limit in mod-login-saml results in 500 responses on SSO login that requires cookie deletion to resolve.

Bumping maximumAuthenticationLifetime from 5 to 8 hours fixes the issue.