### PR TITLE
MODLOGSAML-221: Fix multiple security vulnerabilities in dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </generate_routing_context>
 
     <aspectj.version>1.9.22.1</aspectj.version>
-    <pac4j.version>5.7.7</pac4j.version>
+    <pac4j.version>5.7.10</pac4j.version>
     <vertx-pac4j.version>6.0.3</vertx-pac4j.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
@@ -55,7 +55,15 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.3</version>
+        <version>2.25.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.21.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -71,7 +79,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.25</version>
+        <version>4.5.26</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -156,12 +164,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.83</version>
+      <version>1.84</version>
     </dependency>
 
     <!-- Fix security issues. Recent opensaml-security-api versions replace
@@ -198,11 +206,11 @@
 
     <!-- Fixes Denial of Service (DoS) on deeply nested JSON array or object:
       https://nvd.nist.gov/vuln/detail/CVE-2023-1370 Remove when vertx-pac4j comes
-      with json-smart >= 2.4.10 -->
+      with json-smart >= 2.5.2 -->
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>
-      <version>2.5.1</version>
+      <version>2.5.2</version>
     </dependency>
 
     <!-- Fixes Denial of Service (DoS) in com.fasterxml.woodstox:woodstox-core:


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLOGSAML-221

Bump pac4j from 5.7.7 to 5.7.10 fixing

* https://www.cve.org/CVERecord?id=CVE-2026-40458 – Cross-site Request Forgery (CSRF)

Bump log4j from 2.24.3 to 2.25.4 fixing

* https://www.cve.org/CVERecord?id=CVE-2026-34477 – Improper Validation of Certificate with Host Mismatch
* https://www.cve.org/CVERecord?id=CVE-2026-34480 – Improper Encoding or Escaping of Output
* https://www.cve.org/CVERecord?id=CVE-2026-34479 – Improper Encoding or Escaping of Output
* https://www.cve.org/CVERecord?id=CVE-2026-34478 – Improper Output Neutralization for Logs

Bump jackson from 2.16.1 to 2.21.2 fixing

* https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551 – Allocation of Resources Without Limits or Throttling

Bump vertx from 4.5.25 to 4.5.26.
This transitively bumps netty from 4.1.130.Final to 4.1.132.Final fixing

* https://www.cve.org/CVERecord?id=CVE-2026-33870 – HTTP Request Smuggling
* https://www.cve.org/CVERecord?id=CVE-2026-33871 – Allocation of Resources Without Limits or Throttling

Bump bouncycastle from 1.83 to 1.84 fixing

* https://www.cve.org/CVERecord?id=CVE-2026-5588 – Improper Verification of Cryptographic Signature
* https://www.cve.org/CVERecord?id=CVE-2025-14813 – Use of a Broken or Risky Cryptographic Algorithm
* https://www.cve.org/CVERecord?id=CVE-2026-0636 – LDAP Injection
* https://www.cve.org/CVERecord?id=CVE-2026-5598 – Timing Attack

Bump json-smart from 2.5.1 to 2.5.2 fixing

* https://www.cve.org/CVERecord?id=CVE-2024-57699 – stack overflow caused by {